### PR TITLE
LongsightF Merkle Tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ set(
   "Optionally specify the dependency installation directory relative to the source directory (default: inside dependency folder)"
 )
 
+option(
+  WITH_SUPERCOP
+  "Support for Ed25519 signatures required by ADSNARK"
+  OFF
+)
+
 set(
   OPT_FLAGS
   ""

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ This project aims to help create an ecosystem where a small number of well teste
 
 If you have any ideas for new components, please file a ticket.
 
+# Gadgets
+
+ * 1-of-N
+ * MiMC / LongsightF
+ * SHA256 (full round)
+ * Shamir's Secret Sharing Scheme (generation)
+
 # Components
 
 ## SHA256 hash preimage
@@ -49,13 +56,6 @@ def hashpreimage(preimage, expected):
 ```
 
 # Work-in-progress Components / Ideas
-
-## Polyhash
-
-```python
-def polyhash_preimage(secret, nonce, message[], expected):
-	return expected == polyhash(secret, nonce, message[])
-```
 
 ## Unique Merkle Proof
 

--- a/appendix/.gitignore
+++ b/appendix/.gitignore
@@ -1,0 +1,3 @@
+*.zip
+primes1.txt
+first-mil-primes.txt

--- a/appendix/Makefile
+++ b/appendix/Makefile
@@ -1,0 +1,11 @@
+all:
+	@echo Read Makefile, figure out what to do...
+
+first-mil-primes.txt: primes1.txt
+	cat primes1.txt  | grep -Eo '\s([0-9])+\s' > first-mil-primes.txt
+
+primes1.txt: primes1.zip
+	unzip primes1.zip
+
+primes1.zip:
+	wget -O $@ http://primes.utm.edu/lists/small/millions/primes1.zip

--- a/appendix/poly_biject_permute.py
+++ b/appendix/poly_biject_permute.py
@@ -1,3 +1,11 @@
+"""
+Verifies that various polynomials are bijections across prime numbers
+with different qualities.
+
+This aims to prove, intuitively, that the exponent (x^5) used in the
+LongsightF polynomial is a permutation.
+"""
+
 from ethsnarks.mimc import powmod
 
 from math import gcd

--- a/appendix/poly_surgject_pidgeonhole.py
+++ b/appendix/poly_surgject_pidgeonhole.py
@@ -1,0 +1,52 @@
+"""
+This aims to prove, intuitively, that there is a surjective 
+hash function which, when operating on primes with the same properties
+as the altBN256 curve order, adhere to the pidgeon-hole principle:
+
+	Given two positive integers `n` and `m`, if `n` items are put
+	into `m` holes then at least one hole must contain more than or
+	equal to `n/m` items.
+
+For example, if `H(a,b) -> Z_q`, without control over either `a` or `b`,
+then there is a `1/(2^log2(|Z_q|))` probability of overlap. e.g. if any
+pigeonhole contains more than 3 items then there's a problem, if every
+hole contains 2 items then it's 'perfect', and it should be impossible
+for every hole to contain only 1 item as that would be a bijection.
+"""
+
+from collections import defaultdict
+from math import gcd
+
+from ethsnarks.mimc import powmod
+
+
+def test_pigeonhole(p, polynomial):
+	found = defaultdict(int)
+	for a in range(1, p-1):
+		for b in range(1, p-1):
+			m = polynomial(a, b, p)
+			found[m] += 1
+	#print(found)
+	return sum(found.values())
+
+
+def eval_prime(p):
+	if gcd(p-1, 2) != 2:
+		return
+	if gcd(p-1, 3) != 3:
+		return
+	if gcd(p-1, 4) != 4:
+		return
+	if gcd(p-1, 5) != 1:
+		return
+
+	#poly = lambda a, b, p: (powmod(a, 2, p) + b) % p
+	poly = lambda a, b, p: (a + b) % p
+	result = test_pigeonhole(p, poly)
+	print(p, result, p/result, result/p)
+
+
+with open('first-mil-primes.txt', 'r') as handle:
+	for p in handle:
+		p = int(p.strip())
+		eval_prime(p)

--- a/contracts/LongsightF.sol
+++ b/contracts/LongsightF.sol
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 HarryR
+// License: LGPL-3.0+
+
 pragma solidity ^0.4.24;
 
 library LongsightF

--- a/contracts/MerkleTree.sol
+++ b/contracts/MerkleTree.sol
@@ -1,0 +1,86 @@
+contract MerkelTree {
+    mapping (bytes32 => bool) public serials;
+    mapping (bytes32 => bool) public roots;
+    uint public tree_depth = 29;
+    uint public no_leaves = 536870912;
+    struct Mtree {
+        uint cur;
+        bytes32[536870912][30] leaves2;
+    }
+
+    Mtree public MT;
+
+    event leafAdded(uint index);
+
+    //Merkletree.append(com)
+    function insert(bytes32 com) internal returns (bool res) {
+        require (MT.cur != no_leaves - 1);
+        MT.leaves2[0][MT.cur] = com;
+        updateTree();
+        leafAdded(MT.cur);
+        MT.cur++;
+   
+        return true;
+    }
+
+
+    function getMerkelProof(uint index) constant returns (bytes32[29], uint[29]) {
+
+        uint[29] memory address_bits;
+        bytes32[29] memory merkelProof;
+
+        for (uint i=0 ; i < tree_depth; i++) {
+            address_bits[i] = index%2;
+            if (index%2 == 0) {
+                merkelProof[i] = getUniqueLeaf(MT.leaves2[i][index + 1],i);
+            }
+            else {
+                merkelProof[i] = getUniqueLeaf(MT.leaves2[i][index - 1],i);
+            }
+            index = uint(index/2);
+        }
+        return(merkelProof, address_bits);   
+    }
+    
+     function getSha256(bytes32 input, bytes32 sk) constant returns ( bytes32) { 
+        return(sha256(input , sk)); 
+    }
+
+    function getUniqueLeaf(bytes32 leaf, uint depth) returns (bytes32) {
+        if (leaf == 0x0) {
+            for (uint i=0;i<depth;i++) {
+                leaf = sha256(leaf, leaf);
+            }
+        }
+        return(leaf);
+    }
+    
+    function updateTree() internal returns(bytes32 root) {
+        uint CurrentIndex = MT.cur;
+        bytes32 leaf1;
+        bytes32 leaf2;
+        for (uint i=0 ; i < tree_depth; i++) {
+            uint NextIndex = uint(CurrentIndex/2);
+            if (CurrentIndex%2 == 0) {
+                leaf1 =  MT.leaves2[i][CurrentIndex];
+                leaf2 = getUniqueLeaf(MT.leaves2[i][CurrentIndex + 1], i);
+            } else {
+                leaf1 = getUniqueLeaf(MT.leaves2[i][CurrentIndex - 1], i);
+                leaf2 =  MT.leaves2[i][CurrentIndex];
+            }
+            MT.leaves2[i+1][NextIndex] = (sha256( leaf1, leaf2));
+            CurrentIndex = NextIndex;
+        }
+        return MT.leaves2[tree_depth][0];
+    }
+    
+   
+    function getLeaf(uint j,uint k) constant returns (bytes32 root) {
+        root = MT.leaves2[j][k];
+    }
+
+    function getRoot() constant returns(bytes32 root) {
+        root = MT.leaves2[tree_depth][0];
+    }
+
+}

--- a/contracts/SnarkUtils.sol
+++ b/contracts/SnarkUtils.sol
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 HarryR
+// License: LGPL-3.0+
+
 pragma solidity ^0.4.24;
 
 library SnarkUtils

--- a/ethsnarks/longsight.py
+++ b/ethsnarks/longsight.py
@@ -135,10 +135,10 @@ def LongsightF(x_L, x_R, C, R, e, p, k=0):
     return x_L
 
 
-def LongsightF6p5(x_L, x_R):
+def LongsightF5p5(x_L, x_R):
     p = curve_order
     e = 5
-    R = 6
+    R = 5
     _, C = make_constants("LongsightF", R, e)
     return LongsightF(x_L, x_R, C, R, e, p)
 

--- a/ethsnarks/longsight.py
+++ b/ethsnarks/longsight.py
@@ -118,7 +118,7 @@ def LongsightF(x_L, x_R, C, R, e, p, k=0):
     @param p field prime
     @param k optional key
     """
-    assert R >= 2 * math.ceil(math.log(p) / math.log2(e))
+    #assert R >= 2 * math.ceil(math.log(p) / math.log2(e))
     assert math.gcd(p-1, e) == 1
     assert len(C) == R
 
@@ -133,6 +133,14 @@ def LongsightF(x_L, x_R, C, R, e, p, k=0):
         x_L, x_R = (x_R + j) % p, x_L
 
     return x_L
+
+
+def LongsightF6p5(x_L, x_R):
+    p = curve_order
+    e = 5
+    R = 6
+    _, C = make_constants("LongsightF", R, e)
+    return LongsightF(x_L, x_R, C, R, e, p)
 
 
 def LongsightF152p5(x_L, x_R):

--- a/ethsnarks/longsight.py
+++ b/ethsnarks/longsight.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2018 HarryR
+# License: LGPL-3.0+
+
 """
 https://eprint.iacr.org/2016/492.pdf
 https://eprint.iacr.org/2016/542.pdf
@@ -124,60 +127,10 @@ def LongsightF(x_L, x_R, C, R, e, p, k=0):
     if k != 0:
         assert k > 0 and k < (p-1)
 
-    input_L = x_L
-    input_R = x_R
-
-    round_squares = list()
-    rounds = list()
-
     # Calculate rounds
     for i in range(0, R):
-        t = (x_L + C[i]) % p
-        round_squares.append( (t*t) % p)
-        round_squares.append( (round_squares[-1]*t) % p)
-        round_squares.append( (round_squares[-1]*t) % p)
-        round_squares.append( (round_squares[-1]*t) % p)
-
         j = powmod(x_L + k + C[i], e, p)
-        assert j == round_squares[-1]
-
         x_L, x_R = (x_R + j) % p, x_L
-        rounds.append(x_L)
-
-    # Verify round constraints
-    j = 0
-    for i in range(0, R):
-        if i == 0:
-            c_xL = input_L
-            c_xR = input_R
-        else:
-            c_xL = rounds[i-1]
-            if i == 1:
-                c_xR = input_L
-            else:
-                c_xR = rounds[i-2]
-
-        r1cs_constraint(C[i] + c_xL, C[i] + c_xL, round_squares[j])
-        r1cs_constraint(round_squares[j], C[i] + c_xL, round_squares[j+1])
-        r1cs_constraint(round_squares[j+1], C[i] + c_xL, round_squares[j+2])
-        r1cs_constraint(round_squares[j+2], C[i] + c_xL, round_squares[j+3])
-        r1cs_constraint(1, round_squares[j+3] + c_xR, rounds[i])
-
-        j += 4
-
-    """
-    print("Input L:", input_L)
-    print("Input R:", input_R)
-    print("Result:", x_L)
-
-    print("Rounds:")
-    for i, x in enumerate(rounds):
-        print("\t",i, x)
-
-    print("Intermediate Squares:")
-    for i, x in enumerate(round_squares):
-        print("\t",i, x)
-    """
 
     return x_L
 
@@ -228,5 +181,5 @@ def sponge(p, n, r, F):
 """
 
 if __name__ == "__main__":
-    print(LongsightF152p5(1, 1))
-    #print(make_constants_cxx("LongsightF", 152, 5))
+    #print(LongsightF152p5(1, 1))
+    print(make_constants_cxx("LongsightF", 5, 5))

--- a/ethsnarks/merkletree.py
+++ b/ethsnarks/merkletree.py
@@ -1,6 +1,6 @@
 import hashlib
 import math
-from .longsight import LongsightF6p5, curve_order
+from .longsight import LongsightF5p5, curve_order
 from collections import defaultdict, namedtuple
 
 
@@ -25,7 +25,7 @@ class MerkleProof(object):
 class MerkleHasherLongsightF(object):
     @classmethod
     def hash_pair(cls, left, right):
-        return LongsightF6p5(left, right)
+        return LongsightF5p5(left, right)
 
     @classmethod
     def unique(cls, depth, index):

--- a/ethsnarks/merkletree.py
+++ b/ethsnarks/merkletree.py
@@ -1,0 +1,114 @@
+import hashlib
+import math
+from collections import defaultdict, namedtuple
+
+
+class MerkleProof(object):
+    __slots__ = ('leaf', 'address', 'path', 'hashfn')
+    def __init__(self, leaf, address, path, hashfn):
+        self.leaf = leaf
+        self.address = address
+        self.path = path
+        self.hashfn = hashfn
+
+    def verify(self, root):
+        item = self.leaf
+        for bit, node in zip(self.address, self.path):
+            if bit:
+                item = self.hashfn(node, item)
+            else:
+                item = self.hashfn(item, node)
+        return root == item
+
+
+def _hash_pair_sha256(left, right):
+    if len(left) != 32:
+        raise ValueError("Left incorrect length!")
+    if len(right) != 32:
+        raise ValueError("Right is incorrect length!")
+    hasher = hashlib.sha256()
+    hasher.update(left)
+    hasher.update(right)
+    return hasher.digest()
+
+
+class MerkleTree(object):
+    def __init__(self, n_items, hashfn=None, null_leaf=None):
+        if hashfn is None:
+            hashfn = _hash_pair_sha256
+            null_leaf = b'\0' * 32
+        self._null_leaf = null_leaf
+        self._hashfn = hashfn
+        self._n_items = n_items
+        self._tree_depth = int(math.log(n_items, 2)) + 1
+        self._cur = 0
+        self._leaves = [list() for _ in range(0, self._tree_depth + 1)]
+
+    def __len__(self):
+        return self._cur
+
+    def append(self, leaf):
+        if self._cur >= (self._n_items):
+            raise RuntimeError("Tree Full")
+        self._leaves[0].append(leaf)
+        self._updateTree()
+        self._cur += 1
+
+    def __getitem__(self, key):
+        if not isinstance(key, int):
+            raise TypeError("Invalid key")
+        if key < 0 or key >= self._cur:
+            raise KeyError("Out of bounds")
+        return self._leaves[0][key]
+
+    def index(self, leaf):
+        return self._leaves[0].index(leaf)
+
+    def proof(self, index):
+        leaf = self[index]
+        if index >= self._cur:
+            raise RuntimeError("Proof for invalid item!")
+        address_bits = list()
+        merkle_proof = list()
+        for i in range(0, self._tree_depth):
+            if index % 2 == 0:
+                proof_item = self._getUniqueLeaf(i, index + 1)
+            else:
+                proof_item = self._getUniqueLeaf(i, index - 1)
+            address_bits.append( index % 2 )
+            merkle_proof.append( proof_item )
+            index = index // 2
+        return MerkleProof(leaf, address_bits, merkle_proof, self._hashfn)
+
+    def _updateTree(self):
+        cur_index = self._cur
+        for depth in range(0, self._tree_depth):
+            next_index = cur_index // 2
+            if cur_index % 2 == 0:
+                leaf1 = self._leaves[depth][cur_index]
+                leaf2 = self._getUniqueLeaf(depth, cur_index + 1)
+            else:
+                leaf1 = self._getUniqueLeaf(depth, cur_index - 1)
+                leaf2 = self._leaves[depth][cur_index]
+            node = self._hashfn(leaf1, leaf2)
+            if len(self._leaves[depth+1]) == next_index:
+                self._leaves[depth+1].append(node)
+            else:
+                self._leaves[depth+1][next_index] = node
+            cur_index = next_index
+
+    def _getUniqueLeaf(self, depth, offset):
+        if offset >= len(self._leaves[depth]):
+            leaf = int(depth).to_bytes(2, 'little') + int(offset).to_bytes(30, 'little')
+        else:
+            leaf = self._leaves[depth][offset]
+        return leaf
+
+    def getLeaf(self, depth, offset):
+        return self._leaves[depth][offset]
+
+    @property
+    def root(self):
+        if self._cur == 0:
+            return None
+        return self._leaves[self._tree_depth][0]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,5 +58,10 @@ target_link_libraries(test_hashpreimage snark)
 add_executable(test_one_of_n test/test_one_of_n.cpp)
 target_link_libraries(test_one_of_n snark)
 
+
 add_executable(test_longsightf test/test_longsightf.cpp)
 target_link_libraries(test_longsightf snark)
+
+
+add_executable(test_longsightf_bits test/test_longsightf_bits.cpp)
+target_link_libraries(test_longsightf_bits snark)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,3 +65,8 @@ target_link_libraries(test_longsightf snark)
 
 add_executable(test_longsightf_bits test/test_longsightf_bits.cpp)
 target_link_libraries(test_longsightf_bits snark)
+
+
+add_executable(test_longsightf_merkletree test/test_longsightf_merkletree.cpp)
+target_link_libraries(test_longsightf_merkletree snark)
+

--- a/src/gadgets/longsightf.cpp
+++ b/src/gadgets/longsightf.cpp
@@ -108,7 +108,7 @@ public:
         rounds.allocate(in_pb, round_constants.size(), FMT(in_annotation_prefix, " rounds"));
     }
 
-    const pb_variable<FieldT>& result()
+    const pb_variable<FieldT>& result() const
     {
         return rounds[ round_constants.size() - 1 ];
     }

--- a/src/gadgets/longsightf.cpp
+++ b/src/gadgets/longsightf.cpp
@@ -82,18 +82,18 @@ template<typename FieldT>
 class LongsightF_gadget : public gadget<FieldT>
 {
 public:
-    const std::vector<FieldT> &round_constants;
-    const pb_variable<FieldT> &start_L;
-    const pb_variable<FieldT> &start_R;
+    const std::vector<FieldT> round_constants;
+    const pb_variable<FieldT> start_L;
+    const pb_variable<FieldT> start_R;
 
     pb_variable_array<FieldT> round_squares;
     pb_variable_array<FieldT> rounds;
 
     LongsightF_gadget(
         protoboard<FieldT> &in_pb,
-        const std::vector<FieldT> &in_constants,
-        const pb_variable<FieldT> &in_x_L,
-        const pb_variable<FieldT> &in_x_R,
+        const std::vector<FieldT> in_constants,
+        const pb_variable<FieldT> in_x_L,
+        const pb_variable<FieldT> in_x_R,
         const std::string &in_annotation_prefix="",
         const bool do_allocate=true
     ) :
@@ -220,15 +220,13 @@ template<typename FieldT>
 class LongsightF5p5_gadget : public LongsightF_gadget<FieldT>
 {
 public:
-    std::vector<FieldT> constants_5p5{ LongsightF5p5_constants_assign<FieldT>() };
-
     LongsightF5p5_gadget(
         protoboard<FieldT> &in_pb,
         const pb_variable<FieldT> &in_x_L,
         const pb_variable<FieldT> &in_x_R,
         const std::string &in_annotation_prefix=""
     ) :
-        LongsightF_gadget<FieldT>(in_pb, constants_5p5, in_x_L, in_x_R, in_annotation_prefix, false)
+        LongsightF_gadget<FieldT>(in_pb, LongsightF5p5_constants_assign<FieldT>(), in_x_L, in_x_R, in_annotation_prefix, false)
     {        
         this->allocate();
     }
@@ -239,15 +237,13 @@ template<typename FieldT>
 class LongsightF152p5_gadget : public LongsightF_gadget<FieldT>
 {
 public:
-    const std::vector<FieldT> constants_152p5{ LongsightF152p5_constants_assign<FieldT>() };
-
     LongsightF152p5_gadget(
         protoboard<FieldT> &in_pb,
         const pb_variable<FieldT> &in_x_L,
         const pb_variable<FieldT> &in_x_R,
         const std::string &in_annotation_prefix=""
     ) :
-        LongsightF_gadget<FieldT>(in_pb, constants_152p5, in_x_L, in_x_R, in_annotation_prefix, false)
+        LongsightF_gadget<FieldT>(in_pb, LongsightF152p5_constants_assign<FieldT>(), in_x_L, in_x_R, in_annotation_prefix, false)
     {
         this->allocate();
     }

--- a/src/gadgets/longsightf_bits.cpp
+++ b/src/gadgets/longsightf_bits.cpp
@@ -1,0 +1,101 @@
+#include "longsightf.cpp"
+
+#include <libsnark/gadgetlib1/gadgets/hashes/hash_io.hpp> // digest_variable
+
+using libsnark::packing_gadget;
+using libsnark::digest_variable;
+
+/**
+* LongsightF gadget, but with input and output in bits
+*
+* With the 'bitness' check it requires an additional 764 constraints!
+*/
+template<typename FieldT>
+class LongsightF_bits_gadget : public gadget<FieldT>
+{
+private:
+	/* `allocate_var_index` is private, must use this workaround... */
+	static pb_variable<FieldT> make_variable( protoboard<FieldT> &in_pb, const std::string &annotation="" )
+	{
+		pb_variable<FieldT> x;
+		x.allocate(in_pb, annotation);
+		return x.index;
+	}
+
+public:
+	const pb_variable<FieldT> left_element;
+	packing_gadget<FieldT> left_packer;
+
+	const pb_variable<FieldT> right_element;
+	packing_gadget<FieldT> right_packer;
+
+	LongsightF_gadget<FieldT> hasher;
+
+	const digest_variable<FieldT> output_digest;
+	packing_gadget<FieldT> output_packer;
+
+
+	LongsightF_bits_gadget(
+		protoboard<FieldT> &in_pb,
+		const std::vector<FieldT> &in_constants,
+		const digest_variable<FieldT> &in_left,
+		const digest_variable<FieldT> &in_right,
+		const std::string &in_annotation_prefix=""
+	) :
+		gadget<FieldT>(in_pb, in_annotation_prefix),
+
+		// unpack(left_bits) -> left_element
+		left_element(make_variable(in_pb, FMT(in_annotation_prefix, " left_element"))),
+		left_packer(in_pb, in_left.bits, left_element),
+
+		// unpack(right_bits) -> right_element
+		right_element(make_variable(in_pb, FMT(in_annotation_prefix, " right_element"))),
+		right_packer(in_pb, in_right.bits, right_element),
+
+		// hash(left_element, right_element) -> output_element
+		hasher(in_pb, in_constants, left_element, right_element, FMT(in_annotation_prefix, " hasher")),
+
+		// pack(output_element) -> output_digest
+		output_digest(in_pb, FieldT::capacity(), FMT(in_annotation_prefix, " output_digest")),
+		output_packer(in_pb, output_digest.bits, hasher.result())
+	{
+		assert( in_left.digest_size == get_digest_len() );
+		assert( in_right.digest_size == get_digest_len() );
+	}
+
+	libff::bit_vector get_digest() const
+	{
+		return output_digest.get_digest();
+	}
+
+	void generate_r1cs_constraints(const bool enforce_bitness)
+    {
+    	left_packer.generate_r1cs_constraints(enforce_bitness);
+    	right_packer.generate_r1cs_constraints(enforce_bitness);
+    	hasher.generate_r1cs_constraints();
+    	output_packer.generate_r1cs_constraints(enforce_bitness);
+    }
+
+    void generate_r1cs_witness()
+    {
+    	// bits -> field element
+    	left_packer.generate_r1cs_witness_from_bits();
+    	right_packer.generate_r1cs_witness_from_bits();
+
+    	hasher.generate_r1cs_witness();
+
+    	// field element -> bits
+    	output_packer.generate_r1cs_witness_from_packed();
+    }
+
+    static size_t get_digest_len()
+    {
+    	assert( FieldT::capacity() < 256 );
+        return 256;
+    }
+
+    static size_t get_block_len()
+    {
+    	return get_digest_len() * 2;
+    }
+};

--- a/src/gadgets/longsightf_bits.cpp
+++ b/src/gadgets/longsightf_bits.cpp
@@ -1,101 +1,121 @@
 #include "longsightf.cpp"
 
 #include <libsnark/gadgetlib1/gadgets/hashes/hash_io.hpp> // digest_variable
+#include <libsnark/common/data_structures/merkle_tree.hpp>
 
 using libsnark::packing_gadget;
 using libsnark::digest_variable;
+using libsnark::merkle_authentication_path;
 
 /**
 * LongsightF gadget, but with input and output in bits
 *
 * With the 'bitness' check it requires an additional 764 constraints!
 */
-template<typename FieldT>
+template<typename FieldT, typename HashT>
 class LongsightF_bits_gadget : public gadget<FieldT>
 {
 private:
-	/* `allocate_var_index` is private, must use this workaround... */
-	static pb_variable<FieldT> make_variable( protoboard<FieldT> &in_pb, const std::string &annotation="" )
-	{
-		pb_variable<FieldT> x;
-		x.allocate(in_pb, annotation);
-		return x.index;
-	}
+    /* `allocate_var_index` is private, must use this workaround... */
+    static pb_variable<FieldT> make_variable( protoboard<FieldT> &in_pb, const std::string &annotation="" )
+    {
+        pb_variable<FieldT> x;
+        x.allocate(in_pb, annotation);
+        return x.index;
+    }
 
 public:
-	const pb_variable<FieldT> left_element;
-	packing_gadget<FieldT> left_packer;
+    const pb_variable<FieldT> left_element;
+    packing_gadget<FieldT> left_packer;
 
-	const pb_variable<FieldT> right_element;
-	packing_gadget<FieldT> right_packer;
+    const pb_variable<FieldT> right_element;
+    packing_gadget<FieldT> right_packer;
 
-	LongsightF_gadget<FieldT> hasher;
+    HashT hasher;
 
-	const digest_variable<FieldT> output_digest;
-	packing_gadget<FieldT> output_packer;
+    const digest_variable<FieldT> output_digest;
+    packing_gadget<FieldT> output_packer;
 
+    typedef libff::bit_vector hash_value_type;
+    typedef merkle_authentication_path merkle_authentication_path_type;
 
-	LongsightF_bits_gadget(
-		protoboard<FieldT> &in_pb,
-		const std::vector<FieldT> &in_constants,
-		const digest_variable<FieldT> &in_left,
-		const digest_variable<FieldT> &in_right,
-		const std::string &in_annotation_prefix=""
-	) :
-		gadget<FieldT>(in_pb, in_annotation_prefix),
+    LongsightF_bits_gadget(
+        protoboard<FieldT> &in_pb,
+        const digest_variable<FieldT> &in_left,
+        const digest_variable<FieldT> &in_right,
+        const std::string &in_annotation_prefix=""
+    ) :
+        gadget<FieldT>(in_pb, in_annotation_prefix),
 
-		// unpack(left_bits) -> left_element
-		left_element(make_variable(in_pb, FMT(in_annotation_prefix, " left_element"))),
-		left_packer(in_pb, in_left.bits, left_element),
+        // unpack(left_bits) -> left_element
+        left_element(make_variable(in_pb, FMT(in_annotation_prefix, " left_element"))),
+        left_packer(in_pb, in_left.bits, left_element),
 
-		// unpack(right_bits) -> right_element
-		right_element(make_variable(in_pb, FMT(in_annotation_prefix, " right_element"))),
-		right_packer(in_pb, in_right.bits, right_element),
+        // unpack(right_bits) -> right_element
+        right_element(make_variable(in_pb, FMT(in_annotation_prefix, " right_element"))),
+        right_packer(in_pb, in_right.bits, right_element),
 
-		// hash(left_element, right_element) -> output_element
-		hasher(in_pb, in_constants, left_element, right_element, FMT(in_annotation_prefix, " hasher")),
+        // hash(left_element, right_element) -> output_element
+        hasher(in_pb, left_element, right_element, FMT(in_annotation_prefix, " hasher")),
 
-		// pack(output_element) -> output_digest
-		output_digest(in_pb, FieldT::capacity(), FMT(in_annotation_prefix, " output_digest")),
-		output_packer(in_pb, output_digest.bits, hasher.result())
-	{
-		assert( in_left.digest_size == get_digest_len() );
-		assert( in_right.digest_size == get_digest_len() );
-	}
-
-	libff::bit_vector get_digest() const
-	{
-		return output_digest.get_digest();
-	}
-
-	void generate_r1cs_constraints(const bool enforce_bitness)
+        // pack(output_element) -> output_digest
+        output_digest(in_pb, FieldT::capacity(), FMT(in_annotation_prefix, " output_digest")),
+        output_packer(in_pb, output_digest.bits, hasher.result())
     {
-    	left_packer.generate_r1cs_constraints(enforce_bitness);
-    	right_packer.generate_r1cs_constraints(enforce_bitness);
-    	hasher.generate_r1cs_constraints();
-    	output_packer.generate_r1cs_constraints(enforce_bitness);
+        assert( in_left.digest_size == get_digest_len() );
+        assert( in_right.digest_size == get_digest_len() );
+    }
+
+    libff::bit_vector get_digest() const
+    {
+        return output_digest.get_digest();
+    }
+
+    static libff::bit_vector get_hash(const libff::bit_vector &input)
+    {
+        protoboard<FieldT> pb;
+
+        digest_variable<FieldT> input_left(pb, get_block_len(), "input_left");
+        const libff::bit_vector left_bits(input.begin(), input.begin() + get_digest_len());
+        input_left.generate_r1cs_witness(left_bits);
+
+        digest_variable<FieldT> input_right(pb, get_block_len(), "input_right");
+        const libff::bit_vector right_bits(input.begin() + get_digest_len(), input.end());
+        input_right.generate_r1cs_witness(right_bits);
+
+        LongsightF_bits_gadget<FieldT, HashT> the_gadget(pb, input_left, input_right);
+        the_gadget.generate_r1cs_witness();
+
+        return the_gadget.get_digest();
+    }
+
+    void generate_r1cs_constraints(const bool enforce_bitness)
+    {
+        left_packer.generate_r1cs_constraints(enforce_bitness);
+        right_packer.generate_r1cs_constraints(enforce_bitness);
+        hasher.generate_r1cs_constraints();
+        output_packer.generate_r1cs_constraints(enforce_bitness);
     }
 
     void generate_r1cs_witness()
     {
-    	// bits -> field element
-    	left_packer.generate_r1cs_witness_from_bits();
-    	right_packer.generate_r1cs_witness_from_bits();
+        // bits -> field element
+        left_packer.generate_r1cs_witness_from_bits();
+        right_packer.generate_r1cs_witness_from_bits();
 
-    	hasher.generate_r1cs_witness();
+        hasher.generate_r1cs_witness();
 
-    	// field element -> bits
-    	output_packer.generate_r1cs_witness_from_packed();
+        // field element -> bits
+        output_packer.generate_r1cs_witness_from_packed();
     }
 
     static size_t get_digest_len()
     {
-    	assert( FieldT::capacity() < 256 );
-        return 256;
+        return FieldT::capacity() + 1;
     }
 
     static size_t get_block_len()
     {
-    	return get_digest_len() * 2;
+        return get_digest_len() * 2;
     }
 };

--- a/src/gadgets/longsightf_constants.cpp
+++ b/src/gadgets/longsightf_constants.cpp
@@ -1,7 +1,31 @@
 #pragma once
 
+
 template<typename FieldT>
-void LongsightF152p5_constants( std::vector<FieldT> &round_constants )
+void LongsightF5p5_constants_fill( std::vector<FieldT> &round_constants )
+{
+    round_constants.resize(5);
+    round_constants[0] = FieldT("16141228610716254494246418850894227058386854269090431665976591549148070459029");
+    round_constants[1] = FieldT("5243151816343753305078876980603890071959930727088467525831874325200983521963");
+    round_constants[2] = FieldT("11443535355782020179109906759898317837986670862629041082203606862552526224884");
+    round_constants[3] = FieldT("16540648805601001920805424948549508869776193505507196889296068473215938422144");
+    round_constants[4] = FieldT("13262913797752054119281744993321029046637755854445306089831287067330048370211");
+}
+
+
+template<typename FieldT>
+const std::vector<FieldT> LongsightF5p5_constants_assign( )
+{
+    std::vector<FieldT> round_constants;
+
+    LongsightF5p5_constants_fill<FieldT>(round_constants);
+
+    return round_constants;
+}
+
+
+template<typename FieldT>
+void LongsightF152p5_constants_fill( std::vector<FieldT> &round_constants )
 {
     round_constants.resize(152);
     round_constants[0] = FieldT("7417153685071709436870056242523351150140358124568764639615525440932715960778");
@@ -156,4 +180,15 @@ void LongsightF152p5_constants( std::vector<FieldT> &round_constants )
     round_constants[149] = FieldT("19418594920323449325449185011513449411864950744159548396683709369792136382456");
     round_constants[150] = FieldT("21270966443617552677367273459164784057931628221880574776474664044046473864531");
     round_constants[151] = FieldT("440721317227119536209338173221659451853756565591751100024804937685462586233");
+}
+
+
+template<typename FieldT>
+const std::vector<FieldT> LongsightF152p5_constants_assign( )
+{
+    std::vector<FieldT> round_constants;
+
+    LongsightF152p5_constants_fill<FieldT>(round_constants);
+
+    return round_constants;
 }

--- a/src/gadgets/one_of_n.cpp
+++ b/src/gadgets/one_of_n.cpp
@@ -14,6 +14,34 @@ using libsnark::r1cs_constraint;
 using libsnark::generate_boolean_r1cs_constraint;
 
 
+/**
+* The 1-of-N gadget verifies whether an Input exists within a set of items
+*
+*   e.g. MyValue ∈ Values
+*
+* To do this, it uses 3 variables:
+*
+*  - our_item
+*  - items[]
+*  - toggles[]
+*
+* For example:
+*
+*  - our_item = 4
+*  - items = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+*  - toggles = [0, 0, 0, 1, 0, 0, 0, 0, 0]
+*
+* You must indicate which value is yours by setting the appropriate toggle
+*
+* It works this way because the constraints for each item must be the same
+* Where a constraint is A * B - C. The constraints for the above would be:
+*
+*  - ensure_bitness(toggles)
+*  - sum(toggles) == 1
+*  - (items[i] * toggles[i]) == (toggles[i] * our_item)
+* 
+* This ensures that only 1 item is toggled, and whichever one it is is ours.
+*/
 template<typename FieldT>
 class one_of_n : public gadget<FieldT>
 {

--- a/src/gadgets/one_of_n.cpp
+++ b/src/gadgets/one_of_n.cpp
@@ -42,8 +42,6 @@ public:
     {
         assert( in_items.size() > 0 );
 
-        assert( our_n < in_items.size() );
-
         toggles.allocate(pb, in_items.size(), FMT(annotation_prefix, " toggles"));
 
         toggles_sum.allocate(pb, in_items.size(), FMT(annotation_prefix, " toggles_sum"));

--- a/src/test/test_longsightf.cpp
+++ b/src/test/test_longsightf.cpp
@@ -17,7 +17,7 @@ bool test_LongsightF()
     typedef libff::Fr<ppT> FieldT;
 
     std::vector<FieldT> round_constants;
-    LongsightF152p5_constants(round_constants);
+    LongsightF152p5_constants_fill(round_constants);
 
     protoboard<FieldT> pb;
 

--- a/src/test/test_longsightf_bits.cpp
+++ b/src/test/test_longsightf_bits.cpp
@@ -8,9 +8,6 @@
 #include "utils.cpp"
 
 
-using libsnark::r1cs_ppzksnark_generator;
-using libsnark::r1cs_ppzksnark_prover;
-using libsnark::dual_variable_gadget;
 using libff::convert_bit_vector_to_field_element;
 
 
@@ -18,22 +15,24 @@ template<typename ppT>
 bool test_LongsightF_bits()
 {
     typedef libff::Fr<ppT> FieldT;
+    typedef LongsightF_bits_gadget<FieldT,LongsightF152p5_gadget<FieldT>> HashT;
 
-    std::vector<FieldT> round_constants;
-    LongsightF152p5_constants(round_constants);
+    const std::vector<FieldT> constants_152p5 = LongsightF152p5_constants_assign<FieldT>();
+
+    std::cerr << "constants_152p5 size = " << constants_152p5.size() << "\n";
 
     protoboard<FieldT> pb;
 
     auto expected_L = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
     auto expected_R = FieldT("55049861378429053168722197095693172831329974911537953231866155060049976290");
     
-    digest_variable<FieldT> in_xL_digest(pb, FieldT::capacity() + 1, "xL_digest");
-    digest_variable<FieldT> in_xR_digest(pb, FieldT::capacity() + 1, "xR_digest");
+    digest_variable<FieldT> in_xL_digest(pb, HashT::get_digest_len(), "xL_digest");
+    digest_variable<FieldT> in_xR_digest(pb, HashT::get_digest_len(), "xR_digest");
 
     in_xL_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_L));
     in_xR_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_R));
 
-    LongsightF_bits_gadget<FieldT> the_gadget(pb, round_constants, in_xL_digest, in_xR_digest);
+    HashT the_gadget(pb, in_xL_digest, in_xR_digest);
 
     the_gadget.generate_r1cs_witness();
     the_gadget.generate_r1cs_constraints(false);

--- a/src/test/test_longsightf_bits.cpp
+++ b/src/test/test_longsightf_bits.cpp
@@ -17,10 +17,6 @@ bool test_LongsightF_bits()
     typedef libff::Fr<ppT> FieldT;
     typedef LongsightF_bits_gadget<FieldT,LongsightF152p5_gadget<FieldT>> HashT;
 
-    const std::vector<FieldT> constants_152p5 = LongsightF152p5_constants_assign<FieldT>();
-
-    std::cerr << "constants_152p5 size = " << constants_152p5.size() << "\n";
-
     protoboard<FieldT> pb;
 
     auto expected_L = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
@@ -28,11 +24,13 @@ bool test_LongsightF_bits()
     
     digest_variable<FieldT> in_xL_digest(pb, HashT::get_digest_len(), "xL_digest");
     digest_variable<FieldT> in_xR_digest(pb, HashT::get_digest_len(), "xR_digest");
+    block_variable<FieldT> in_block(pb, in_xL_digest, in_xR_digest, "in_block");
+    digest_variable<FieldT> output_digest(pb, HashT::get_digest_len(), "output_digest");
 
     in_xL_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_L));
     in_xR_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_R));
 
-    HashT the_gadget(pb, in_xL_digest, in_xR_digest);
+    HashT the_gadget(pb, HashT::get_block_len(), in_block, output_digest);
 
     the_gadget.generate_r1cs_witness();
     the_gadget.generate_r1cs_constraints(false);

--- a/src/test/test_longsightf_bits.cpp
+++ b/src/test/test_longsightf_bits.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2018 HarryR
+// License: LGPL-3.0+
+
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
+
+#include "gadgets/longsightf_bits.cpp"
+#include "utils.cpp"
+
+
+using libsnark::r1cs_ppzksnark_generator;
+using libsnark::r1cs_ppzksnark_prover;
+using libsnark::dual_variable_gadget;
+using libff::convert_bit_vector_to_field_element;
+
+
+template<typename ppT>
+bool test_LongsightF_bits()
+{
+    typedef libff::Fr<ppT> FieldT;
+
+    std::vector<FieldT> round_constants;
+    LongsightF152p5_constants(round_constants);
+
+    protoboard<FieldT> pb;
+
+    auto expected_L = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
+    auto expected_R = FieldT("55049861378429053168722197095693172831329974911537953231866155060049976290");
+    
+    digest_variable<FieldT> in_xL_digest(pb, FieldT::capacity() + 1, "xL_digest");
+    digest_variable<FieldT> in_xR_digest(pb, FieldT::capacity() + 1, "xR_digest");
+
+    in_xL_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_L));
+    in_xR_digest.generate_r1cs_witness(convert_field_element_to_bit_vector(expected_R));
+
+    LongsightF_bits_gadget<FieldT> the_gadget(pb, round_constants, in_xL_digest, in_xR_digest);
+
+    the_gadget.generate_r1cs_witness();
+    the_gadget.generate_r1cs_constraints(false);
+
+    // TODO: verify decoded bits
+    if( pb.val(the_gadget.left_element) != expected_L )
+    {
+        std::cerr << "L mismatch!\n";
+        return false;
+    }
+
+    if( pb.val(the_gadget.right_element) != expected_R )
+    {
+        std::cerr << "R mismatch!\n";
+        return false;
+    }
+
+    auto result_expected = FieldT("11801552584949094581972187388927133931539817817986253233814495442311083852545");
+    if( pb.val(the_gadget.hasher.result()) != result_expected ) {
+        std::cerr << "Internal result incorrect!\n";
+        return false;
+    }
+
+    auto result_actual = convert_bit_vector_to_field_element<FieldT>(the_gadget.get_digest());
+    if( result_expected != result_actual ) {
+        std::cerr << "Unexpected result!\n";
+        return false;
+    }
+
+    std::cerr << "Constraints: " << pb.num_constraints() << "\n";
+
+    return pb.is_satisfied();
+}
+
+
+int main( int argc, char **argv )
+{
+    // Types for board
+    typedef libff::alt_bn128_pp ppT;    
+    ppT::init_public_params();
+
+    if( ! test_LongsightF_bits<ppT>() )
+    {
+        std::cerr << "FAIL\n";
+        return 1;
+    }
+
+    std::cout << "OK\n";
+    return 0;
+}

--- a/src/test/test_longsightf_merkletree.cpp
+++ b/src/test/test_longsightf_merkletree.cpp
@@ -6,15 +6,21 @@
 
 #include <libsnark/common/data_structures/set_commitment.hpp>
 
+#include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_authentication_path_variable.hpp>
+#include <libsnark/gadgetlib1/gadgets/merkle_tree/merkle_tree_check_read_gadget.hpp>
+
 #include "gadgets/longsightf_bits.cpp"
 #include "utils.cpp"
 
 using libsnark::set_commitment_accumulator;
 using libff::convert_bit_vector_to_field_element;
-
+using libsnark::two_to_one_CRH;
+using libsnark::merkle_authentication_node;
+using libsnark::merkle_authentication_path_variable;
+using libsnark::merkle_tree_check_read_gadget;
 
 template<typename ppT>
-bool test_LongsightF_merkletree()
+bool test_LongsightF_merkle_read()
 {
     typedef libff::Fr<ppT> FieldT;
     typedef LongsightF_bits_gadget<FieldT, LongsightF152p5_gadget<FieldT>> HashT;
@@ -33,17 +39,101 @@ bool test_LongsightF_merkletree()
     digest_variable<FieldT> digest_expected(pb, HashT::get_digest_len(), "digest_expected");
     digest_expected.generate_r1cs_witness(convert_field_element_to_bit_vector(result_expected));
 
+    auto tto_result = two_to_one_CRH<HashT>(digest_A.get_digest(), digest_B.get_digest());
+    if( tto_result != digest_expected.get_digest() ) {
+        std::cerr << "merkle_tree two_to_one_CRH mismatch!\n";
+        return false;
+    }
+
+    std::vector<merkle_authentication_node> path { digest_B.get_digest() };
+    size_t tree_depth = 1;
+    
+    pb_variable_array<FieldT> address_bits_var;
+    address_bits_var.allocate(pb, tree_depth, "address_bits");
+    merkle_authentication_path_variable<FieldT, HashT> path_var(pb, tree_depth, "path");
+    merkle_tree_check_read_gadget<FieldT,HashT> read_gadget(
+            pb,
+            tree_depth,
+            address_bits_var,
+            digest_A,           // leaf_digest
+            digest_expected,    // root_digest
+            path_var,
+            ONE,
+            "read_gadget" );
+
+    path_var.generate_r1cs_constraints();
+    read_gadget.generate_r1cs_constraints();
+
+    address_bits_var.fill_with_bits(pb, {0});
+    read_gadget.generate_r1cs_witness();
+
+
+    // TODO: generate constraints
+
+    // TODO: generate witness
+    return pb.is_satisfied()    ;
+}
+
+
+template<typename ppT>
+bool test_LongsightF_set_commitment()
+{
+    typedef libff::Fr<ppT> FieldT;
+    typedef LongsightF_bits_gadget<FieldT, LongsightF152p5_gadget<FieldT>> HashT;
+
+    protoboard<FieldT> pb;
+
+    auto item_A = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
+    digest_variable<FieldT> digest_A(pb, HashT::get_digest_len(), "digest_A");
+    digest_A.generate_r1cs_witness(convert_field_element_to_bit_vector(item_A));
+
+    auto item_B = FieldT("55049861378429053168722197095693172831329974911537953231866155060049976290");
+    digest_variable<FieldT> digest_B(pb, HashT::get_digest_len(), "digest_B");
+    digest_B.generate_r1cs_witness(convert_field_element_to_bit_vector(item_B));
+
+    auto result_expected = FieldT("11801552584949094581972187388927133931539817817986253233814495442311083852545");
+    digest_variable<FieldT> digest_expected(pb, HashT::get_digest_len(), "digest_expected");
+    digest_expected.generate_r1cs_witness(convert_field_element_to_bit_vector(result_expected));
+
+    auto tto_result = two_to_one_CRH<HashT>(digest_A.get_digest(), digest_B.get_digest());
+    if( tto_result != digest_expected.get_digest() ) {
+        std::cerr << "merkle_tree two_to_one_CRH mismatch!\n";
+        return false;
+    }
+
     print_bv("digest A", digest_A.get_digest());
     print_bv("digest B", digest_B.get_digest());
 
     set_commitment_accumulator<HashT> accumulator(2, HashT::get_digest_len());
+
     accumulator.add(digest_A.get_digest());
     accumulator.add(digest_B.get_digest());
 
+    // TODO: verify known values
+    // Root should be H(A,B)
+    // Path A should be B
+    // Path B should be A
+    // Path A != Path B
     print_bv("root", accumulator.get_commitment());
-    print_bv("expected root", digest_expected.get_digest());
-    //std::cerr << "proof A " << accumulator.get_membership_proof(digest_A.get_digest()) << "\n";
-    //std::cerr << "proof B " << accumulator.get_membership_proof(digest_B.get_digest()) << "\n";
+    print_bv("\nexpected root", digest_expected.get_digest());
+
+    std::cout << "\n";
+    auto proof_A = accumulator.get_membership_proof(digest_A.get_digest());
+    int i = 0;
+    std::cout << "addr A " << proof_A.address << "\n";
+    for( auto& node : proof_A.merkle_path ) {
+        std::cout << i << " ";
+        print_bv("A", node);
+    }
+
+    std::cout << "\n";
+    auto proof_B = accumulator.get_membership_proof(digest_B.get_digest());
+    i = 0;
+    std::cout << "addr B " << proof_B.address << "\n";
+    for( auto& node : proof_A.merkle_path ) {
+        std::cout << i << " ";
+        print_bv("B", node);
+    }
 
     return pb.is_satisfied();
 }
@@ -55,9 +145,15 @@ int main( int argc, char **argv )
     typedef libff::alt_bn128_pp ppT;    
     ppT::init_public_params();
 
-    if( ! test_LongsightF_merkletree<ppT>() )
+    if( ! test_LongsightF_merkle_read<ppT>() )
     {
-        std::cerr << "FAIL\n";
+        std::cerr << "FAIL merkle read\n";
+        return 1;
+    }
+
+    if( ! test_LongsightF_set_commitment<ppT>() )
+    {
+        std::cerr << "FAIL set commitment\n";
         return 1;
     }
 

--- a/src/test/test_longsightf_merkletree.cpp
+++ b/src/test/test_longsightf_merkletree.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 HarryR
+// License: LGPL-3.0+
+
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
+
+#include <libsnark/common/data_structures/set_commitment.hpp>
+
+#include "gadgets/longsightf_bits.cpp"
+#include "utils.cpp"
+
+using libsnark::set_commitment_accumulator;
+using libff::convert_bit_vector_to_field_element;
+
+
+template<typename ppT>
+bool test_LongsightF_merkletree()
+{
+    typedef libff::Fr<ppT> FieldT;
+    typedef LongsightF_bits_gadget<FieldT, LongsightF152p5_gadget<FieldT>> HashT;
+
+    protoboard<FieldT> pb;
+
+    auto item_A = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
+    digest_variable<FieldT> digest_A(pb, HashT::get_digest_len(), "digest_A");
+    digest_A.generate_r1cs_witness(convert_field_element_to_bit_vector(item_A));
+
+    auto item_B = FieldT("55049861378429053168722197095693172831329974911537953231866155060049976290");
+    digest_variable<FieldT> digest_B(pb, HashT::get_digest_len(), "digest_B");
+    digest_B.generate_r1cs_witness(convert_field_element_to_bit_vector(item_B));
+
+    auto result_expected = FieldT("11801552584949094581972187388927133931539817817986253233814495442311083852545");
+    digest_variable<FieldT> digest_expected(pb, HashT::get_digest_len(), "digest_expected");
+    digest_expected.generate_r1cs_witness(convert_field_element_to_bit_vector(result_expected));
+
+    print_bv("digest A", digest_A.get_digest());
+    print_bv("digest B", digest_B.get_digest());
+
+    set_commitment_accumulator<HashT> accumulator(2, HashT::get_digest_len());
+    accumulator.add(digest_A.get_digest());
+    accumulator.add(digest_B.get_digest());
+
+    print_bv("root", accumulator.get_commitment());
+    print_bv("expected root", digest_expected.get_digest());
+    //std::cerr << "proof A " << accumulator.get_membership_proof(digest_A.get_digest()) << "\n";
+    //std::cerr << "proof B " << accumulator.get_membership_proof(digest_B.get_digest()) << "\n";
+
+    return pb.is_satisfied();
+}
+
+
+int main( int argc, char **argv )
+{
+    // Types for board
+    typedef libff::alt_bn128_pp ppT;    
+    ppT::init_public_params();
+
+    if( ! test_LongsightF_merkletree<ppT>() )
+    {
+        std::cerr << "FAIL\n";
+        return 1;
+    }
+
+    std::cout << "OK\n";
+    return 0;
+}

--- a/src/test/test_longsightf_merkletree.cpp
+++ b/src/test/test_longsightf_merkletree.cpp
@@ -70,70 +70,6 @@ bool test_LongsightF_merkle_read()
 }
 
 
-template<typename ppT>
-bool test_LongsightF_set_commitment()
-{
-    typedef libff::Fr<ppT> FieldT;
-    typedef LongsightF_bits_gadget<FieldT, LongsightF152p5_gadget<FieldT>> HashT;
-
-    protoboard<FieldT> pb;
-
-    auto item_A = FieldT("21871881226116355513319084168586976250335411806112527735069209751513595455673");
-    digest_variable<FieldT> digest_A(pb, HashT::get_digest_len(), "digest_A");
-    digest_A.generate_r1cs_witness(convert_field_element_to_bit_vector(item_A));
-
-    auto item_B = FieldT("55049861378429053168722197095693172831329974911537953231866155060049976290");
-    digest_variable<FieldT> digest_B(pb, HashT::get_digest_len(), "digest_B");
-    digest_B.generate_r1cs_witness(convert_field_element_to_bit_vector(item_B));
-
-    auto result_expected = FieldT("11801552584949094581972187388927133931539817817986253233814495442311083852545");
-    digest_variable<FieldT> digest_expected(pb, HashT::get_digest_len(), "digest_expected");
-    digest_expected.generate_r1cs_witness(convert_field_element_to_bit_vector(result_expected));
-
-    auto tto_result = two_to_one_CRH<HashT>(digest_A.get_digest(), digest_B.get_digest());
-    if( tto_result != digest_expected.get_digest() ) {
-        std::cerr << "merkle_tree two_to_one_CRH mismatch!\n";
-        return false;
-    }
-
-    print_bv("digest A", digest_A.get_digest());
-    print_bv("digest B", digest_B.get_digest());
-
-    set_commitment_accumulator<HashT> accumulator(2, HashT::get_digest_len());
-
-    accumulator.add(digest_A.get_digest());
-    accumulator.add(digest_B.get_digest());
-
-    // TODO: verify known values
-    // Root should be H(A,B)
-    // Path A should be B
-    // Path B should be A
-    // Path A != Path B
-    print_bv("root", accumulator.get_commitment());
-    print_bv("\nexpected root", digest_expected.get_digest());
-
-    std::cout << "\n";
-    auto proof_A = accumulator.get_membership_proof(digest_A.get_digest());
-    int i = 0;
-    std::cout << "addr A " << proof_A.address << "\n";
-    for( auto& node : proof_A.merkle_path ) {
-        std::cout << i << " ";
-        print_bv("A", node);
-    }
-
-    std::cout << "\n";
-    auto proof_B = accumulator.get_membership_proof(digest_B.get_digest());
-    i = 0;
-    std::cout << "addr B " << proof_B.address << "\n";
-    for( auto& node : proof_A.merkle_path ) {
-        std::cout << i << " ";
-        print_bv("B", node);
-    }
-
-    return pb.is_satisfied();
-}
-
-
 int main( int argc, char **argv )
 {
     // Types for board
@@ -143,12 +79,6 @@ int main( int argc, char **argv )
     if( ! test_LongsightF_merkle_read<ppT>() )
     {
         std::cerr << "FAIL merkle read\n";
-        return 1;
-    }
-
-    if( ! test_LongsightF_set_commitment<ppT>() )
-    {
-        std::cerr << "FAIL set commitment\n";
         return 1;
     }
 

--- a/test/test_longsight.py
+++ b/test/test_longsight.py
@@ -2,7 +2,7 @@ import unittest
 
 from random import randint
 
-from ethsnarks.mimc import LongsightF, LongsightL, LongsightF152p5, curve_order
+from ethsnarks.longsight import LongsightF, LongsightL, LongsightF152p5, curve_order
 
 class MiMCTests(unittest.TestCase):
     def test_LongsightF_known1(self):

--- a/test/test_merkle.py
+++ b/test/test_merkle.py
@@ -1,25 +1,14 @@
 import unittest
 
-
+import hashlib
 from ethsnarks.utils import genMerkelTree, getMerkelProof, sha256, initMerkleTree, hashPadded, libsnark2python
-from ethsnarks.merkletree import MerkleTree
-
-
-def verifyMerkleProof(root, leaf, path, address_bits):
-    item = leaf
-    for i, node in enumerate(path):
-        bit = address_bits[i]
-        if not bit:
-            item = hashPadded(node, item)
-        else:
-            item = hashPadded(item, node)
-    return root == node
+from ethsnarks.merkletree import MerkleTree, MerkleHasherLongsightF, MerkleHasherSHA256, curve_order
 
 
 class TestMerkleTree(unittest.TestCase):
-    def test_incremental(self):
+    def test_incremental_sha256(self):
         n_items = 100
-        tree = MerkleTree(n_items)
+        tree = MerkleTree(n_items, MerkleHasherSHA256)
         self.assertEqual(tree.root, None)
         self.assertEqual(len(tree), 0)
 
@@ -38,76 +27,29 @@ class TestMerkleTree(unittest.TestCase):
             for m in range(0, len(tree) - 1):
                 self.assertTrue(tree.proof(m).verify(tree.root))
 
-    """
-    def test_tree(self):
-        tree_depth = 5
-        leaves, nullifiers, sks = initMerkleTree(tree_depth) 
-        root, tree = genMerkelTree(tree_depth, leaves)
-        print("Leaves", leaves)
-        print("Tree", tree)
-        print("Root", root)
-        for address, (nullifier , sk) in enumerate(zip(nullifiers, sks)):
-            path, address_bits = getMerkelProof(leaves, address, tree_depth)
-            print(root, path, address_bits)
-            leaf = hashPadded(nullifier, sk)
-            print(verifyMerkleProof(root, leaf, path, address_bits))
-            break
-            # TODO: verify merkle proof
+    def test_incremental_longsight(self):
+        n_items = 100
+        tree = MerkleTree(n_items, MerkleHasherLongsightF)
+        self.assertEqual(tree.root, None)
+        self.assertEqual(len(tree), 0)
 
-    def test_getMerkelProof(self):
-        proof1, address1 =  getMerkelProof([
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "0x0000000000000000000000000000000000000000000000000000000000000000"],
-                0, 2)
-        self.assertEqual(proof1[0], "0x0000000000000000000000000000000000000000000000000000000000000000")
-        self.assertEqual(proof1[1], "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b")
-        self.assertEqual(address1[0], 0)
-        self.assertEqual(address1[1], 0)
+        previous_root = None
+        for n in range(0, n_items):
+            hasher = hashlib.sha256()
+            hasher.update(bytes([n]) * 32)
+            item = int.from_bytes(hasher.digest(), 'little') % curve_order
+            tree.append(item)
+            self.assertEqual(len(tree), n + 1)
 
-    def test_GenMerkelTree(self):
-        mr1, tree = genMerkelTree(1, ["0x0000000000000000000000000000000000000000000000000000000000000000",
-                                      "0x0000000000000000000000000000000000000000000000000000000000000000"])
+            self.assertNotEqual(tree.root, previous_root)
+            previous_root = tree.root
+            proof = tree.proof(n)
+            self.assertTrue(proof.verify(tree.root))
 
-        mr2, tree = genMerkelTree(2, ["0x0000000000000000000000000000000000000000000000000000000000000000",
-                                      "0x0000000000000000000000000000000000000000000000000000000000000000", 
-                                      "0x0000000000000000000000000000000000000000000000000000000000000000",
-                                      "0x0000000000000000000000000000000000000000000000000000000000000000"])
+            # Then verify all existing items can also be proven to be in the tree
+            for m in range(0, len(tree) - 1):
+                self.assertTrue(tree.proof(m).verify(tree.root))
 
-        mr3, tree = genMerkelTree(29, ["0x0000000000000000000000000000000000000000000000000000000000000000",
-                                       "0x0000000000000000000000000000000000000000000000000000000000000000"])
-
-        self.assertEqual(mr1, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b") 
-
-        self.assertEqual(mr2, "0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71")
-
-
-    def testHashPadded(self):
-        left = "0x0000000000000000000000000000000000000000000000000000000000000000"
-        right = "0x0000000000000000000000000000000000000000000000000000000000000000"
-        res = hashPadded(left , right)
-        self.assertEqual(res, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b")
-
-
-    def testlibsnarkTopython(self):
-        inputs = [12981351829201453377820191526040524295325907810881751591725375521336092323040, 
-                  2225095499654173609649711272123535458680077283826030252600915820706026312895, 
-                  10509931637877506470161905650895697133838017786875388895008260393592381807236, 
-                  11784807906137262651861317232543524609532737193375988426511007536308407308209, 17]
-
-        inputs = [9782619478414927069440250629401329418138703122237912437975467993246167708418,
-                  2077680306600520305813581592038078188768881965413185699798221798985779874888,
-                  4414150718664423886727710960459764220828063162079089958392546463165678021703,
-                  7513790795222206681892855620762680219484336729153939269867138100414707910106,
-                  902]
-
-        output = libsnark2python(inputs)
-        self.assertEqual(output[0], "0x40cde80490e78bc7d1035cbc78d3e6be3e41b2fdfad473782e02e226cc2305a8")
-        self.assertEqual(output[1], "0x918e88a16d0624cd5ca4695bd84e23e4a6c8a202ce85560d3c66d4ed39bf4938")
-        self.assertEqual(output[2], "0x8dd3ea28fe8d04f3e15b787fec7e805e152fe7d3302d0122c8522bee1290e4b7")
-        self.assertEqual(output[3], "0x47a6bbcf8fa3667431e895f08cbd8ec2869a31698d9cf91e5bfd94cbca72161c")
-    """
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_merkle.py
+++ b/test/test_merkle.py
@@ -2,6 +2,7 @@ import unittest
 
 
 from ethsnarks.utils import genMerkelTree, getMerkelProof, sha256, initMerkleTree, hashPadded, libsnark2python
+from ethsnarks.merkletree import MerkleTree
 
 
 def verifyMerkleProof(root, leaf, path, address_bits):
@@ -16,6 +17,28 @@ def verifyMerkleProof(root, leaf, path, address_bits):
 
 
 class TestMerkleTree(unittest.TestCase):
+    def test_incremental(self):
+        n_items = 100
+        tree = MerkleTree(n_items)
+        self.assertEqual(tree.root, None)
+        self.assertEqual(len(tree), 0)
+
+        previous_root = None
+        for n in range(0, n_items):
+            item = bytes([n]) * 32
+            tree.append(item)
+            self.assertEqual(len(tree), n + 1)
+
+            self.assertNotEqual(tree.root, previous_root)
+            previous_root = tree.root
+            proof = tree.proof(n)
+            self.assertTrue(proof.verify(tree.root))
+
+            # Then verify all existing items can also be proven to be in the tree
+            for m in range(0, len(tree) - 1):
+                self.assertTrue(tree.proof(m).verify(tree.root))
+
+    """
     def test_tree(self):
         tree_depth = 5
         leaves, nullifiers, sks = initMerkleTree(tree_depth) 
@@ -84,7 +107,7 @@ class TestMerkleTree(unittest.TestCase):
         self.assertEqual(output[1], "0x918e88a16d0624cd5ca4695bd84e23e4a6c8a202ce85560d3c66d4ed39bf4938")
         self.assertEqual(output[2], "0x8dd3ea28fe8d04f3e15b787fec7e805e152fe7d3302d0122c8522bee1290e4b7")
         self.assertEqual(output[3], "0x47a6bbcf8fa3667431e895f08cbd8ec2869a31698d9cf91e5bfd94cbca72161c")
-
+    """
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This implements an incremental merkle tree class in Python and the necessary backend SNARK circuits to verify the proofs.

The hash used for the merkle tree is LongsightF5p5, where 5 rounds with exponent of 5.

This is because 152 rounds are needed to meet the difficulty level outline in the MiMC paper, and 29*5 is... nearly there. This means that hashing the leaf, then proving a merkle path 29 entries long is about the same cost as two full hashes at 152 rounds each, rather than 30 hashes at 152 rounds each.