### PR TITLE
Fixing off-by-one error in ethsnarks::bit_list_to_ints()

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,7 +23,7 @@ libff::bit_vector bytes_to_bv(const uint8_t *in_bytes, const size_t in_count)
 std::vector<unsigned long> bit_list_to_ints(std::vector<bool> bit_list, const size_t wordsize)
 {
     std::vector<unsigned long> res;
-    size_t iterations = bit_list.size()/wordsize+1;
+    size_t iterations = bit_list.size()/wordsize;
 
     for (size_t i = 0; i < iterations; ++i)
     {


### PR DESCRIPTION
bit_list_to_ints() populates a word vector from a list of bits, given a word size
desired for each element of the returned vector.  There is an off-by-one error
in its calculation of the number of words that causes it to read one word past the end of its input bit list.

For example, if you have a 256 bit input and a word size of 8, the routine will
attempt to read populate 33 bytes into its return vector, reading 8 bits beyond the end of its input bit list.

This was causing the test_hashpreimage test case to report a successful test result, but still fault with an 'Abort Trap: 6' error.  It may also have been causing a more direct false negative in the test_sha256_full test case.

I was only analyzing test_hashpreimage when I found and corrected this problem,
but it appears to have also accidentally fixed test_sha256_full, although I have
not done enough analysis to be able to offer a guess as to why.