### PR TITLE
Fixes #25 - Minimal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,9 @@ project(ethsnarks)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
-
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Common compilation flags and warning configuration
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wfatal-errors -Wno-unused-variable -pthread")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wfatal-errors -Wno-unused-variable")
    if("${MULTICORE}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
   endif()
@@ -29,6 +28,22 @@ set(
 set(
   DEPENDS_DIR
   "${CMAKE_CURRENT_SOURCE_DIR}/depends"
+  CACHE
+  STRING
+  "Optionally specify the dependency installation directory relative to the source directory (default: inside dependency folder)"
+)
+
+set(
+  DEPENDS_DIR_LIBSNARK
+  "${CMAKE_CURRENT_SOURCE_DIR}/depends/libsnark/"
+  CACHE
+  STRING
+  "Optionally specify the dependency installation directory relative to the source directory (default: inside dependency folder)"
+)
+
+set(
+  DEPENDS_DIR_LIBFF
+  "${DEPENDS_DIR_LIBSNARK}/depends/libff/"
   CACHE
   STRING
   "Optionally specify the dependency installation directory relative to the source directory (default: inside dependency folder)"
@@ -121,8 +136,42 @@ else()
   add_definitions(-DNO_PROCPS)
 endif()
 
-include_directories(.)
+include_directories(
+  ${DEPENDS_DIR}/libsnark
+  ${DEPENDS_DIR}/libsnark/depends/libff
+  ${DEPENDS_DIR}/libsnark/depends/libfqfft)
 
-add_subdirectory(depends)
+
+add_library(
+  ff
+  STATIC
+
+  ${DEPENDS_DIR_LIBFF}/libff/algebra/curves/alt_bn128/alt_bn128_g1.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/algebra/curves/alt_bn128/alt_bn128_g2.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/algebra/curves/alt_bn128/alt_bn128_init.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/algebra/curves/alt_bn128/alt_bn128_pairing.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/algebra/curves/alt_bn128/alt_bn128_pp.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/common/double.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/common/profiling.cpp
+  ${DEPENDS_DIR_LIBFF}/libff/common/utils.cpp
+)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+find_library(GMP_LIBRARY gmp)
+if(GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(gmp_library_type SHARED)
+else()
+  set(gmp_library_type STATIC)
+endif()
+message(STATUS "GMP: ${GMP_LIBRARY}, ${GMP_INCLUDE_DIR}")
+add_library(GMP::gmp ${gmp_library_type} IMPORTED)
+set_target_properties(
+  GMP::gmp PROPERTIES
+  IMPORTED_LOCATION ${GMP_LIBRARY}
+  INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
+)
+target_link_libraries(ff GMP::gmp)
+
+#add_subdirectory(depends)
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
   endif()
     # Default optimizations flags (to override, use -DOPT_FLAGS=...)
-  if("${OPT_FLAGS}" STREQUAL "")
-    set(OPT_FLAGS "-O3")
-  endif()
 endif()
 
 
@@ -47,12 +44,6 @@ set(
   CACHE
   STRING
   "Optionally specify the dependency installation directory relative to the source directory (default: inside dependency folder)"
-)
-
-option(
-  WITH_SUPERCOP
-  "Support for Ed25519 signatures required by ADSNARK"
-  OFF
 )
 
 set(
@@ -122,6 +113,9 @@ endif()
 
 if("${DEBUG}")
   add_definitions(-DDEBUG=1)
+  add_compile_options(-g)
+else()
+  add_compile_options(-O3)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,12 +120,65 @@ if("${MULTICORE}")
   add_definitions(-DMULTICORE=1)
 endif()
 
+if("${DEBUG}")
+  add_definitions(-DDEBUG=1)
+endif()
 
-add_compile_options(-fPIC)
+
+if("${BINARY_OUTPUT}")
+  add_definitions(-DBINARY_OUTPUT)
+endif()
+
+if("${MONTGOMERY_OUTPUT}")
+  add_definitions(-DMONTGOMERY_OUTPUT)
+endif()
+
+if(NOT "${USE_PT_COMPRESSION}")
+  add_definitions(-DNO_PT_COMPRESSION=1)
+endif()
+
+
+if("${USE_MIXED_ADDITION}")
+  add_definitions(-DUSE_MIXED_ADDITION=1)
+endif()
 
 if("${CPPDEBUG}")
   add_definitions(-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC)
 endif()
+
+include(FindPkgConfig)
+if("${WITH_PROCPS}")
+  pkg_check_modules(
+    PROCPS
+    REQUIRED
+
+    libprocps
+  )
+else()
+  add_definitions(
+    -DNO_PROCPS
+  )
+endif()
+
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+find_library(GMP_LIBRARY gmp)
+if(GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(gmp_library_type SHARED)
+else()
+  set(gmp_library_type STATIC)
+endif()
+message(STATUS "GMP: ${GMP_LIBRARY}, ${GMP_INCLUDE_DIR}")
+add_library(GMP::gmp ${gmp_library_type} IMPORTED)
+set_target_properties(
+  GMP::gmp PROPERTIES
+  IMPORTED_LOCATION ${GMP_LIBRARY}
+  INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
+)
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx)
+
+
+add_compile_options(-fPIC)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPT_FLAGS}")
 
@@ -156,21 +209,7 @@ add_library(
   ${DEPENDS_DIR_LIBFF}/libff/common/utils.cpp
 )
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h)
-find_library(GMP_LIBRARY gmp)
-if(GMP_LIBRARY MATCHES ${CMAKE_SHARED_LIBRARY_SUFFIX})
-  set(gmp_library_type SHARED)
-else()
-  set(gmp_library_type STATIC)
-endif()
-message(STATUS "GMP: ${GMP_LIBRARY}, ${GMP_INCLUDE_DIR}")
-add_library(GMP::gmp ${gmp_library_type} IMPORTED)
-set_target_properties(
-  GMP::gmp PROPERTIES
-  IMPORTED_LOCATION ${GMP_LIBRARY}
-  INTERFACE_INCLUDE_DIRECTORIES ${GMP_INCLUDE_DIR}
-)
-target_link_libraries(ff GMP::gmp)
+target_link_libraries(ff GMP::gmp gmpxx ${PROCPS_LIBRARIES})
 
 #add_subdirectory(depends)
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ set_property(TARGET miximus PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 
 add_library(hashpreimage SHARED mod/hashpreimage.cpp)
-target_link_libraries(hashpreimage ethsnarks_common)
+target_link_libraries(hashpreimage ethsnarks_common crypto)
 set_property(TARGET hashpreimage PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 
@@ -25,7 +25,7 @@ target_link_libraries(miximus_cli miximus_static)
 
 
 add_executable(hashpreimage_cli hashpreimage_cli.cpp)
-target_link_libraries(hashpreimage_cli ethsnarks_common)
+target_link_libraries(hashpreimage_cli ethsnarks_common crypto)
 
 
 add_executable(verify verify.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,8 @@
-include_directories(
-  .
-  ${DEPENDS_DIR}/libsnark
-  ${DEPENDS_DIR}/libsnark/depends/libff
-  ${DEPENDS_DIR}/libsnark/depends/libfqfft)
+include_directories(.)
+
 
 add_library(ethsnarks_common STATIC export.cpp import.cpp stubs.cpp utils.cpp)
-target_link_libraries(ethsnarks_common ethsnarks_gadgets snark)
+target_link_libraries(ethsnarks_common ethsnarks_gadgets ff)
 
 add_library(miximus_objs OBJECT mod/miximus.cpp)
 

--- a/src/gadgets/longsightl.cpp
+++ b/src/gadgets/longsightl.cpp
@@ -93,28 +93,28 @@ void LongsightL_round::generate_r1cs_constraints()
                 ConstraintT(
                     t,
                     t,
-                    var_sq2));
+                    var_sq2), "t*t=sq2");
 
     // sq2 * sq2 == sq4 == t^4
     this->pb.add_r1cs_constraint(
                 ConstraintT(
                     var_sq2,
                     var_sq2,
-                    var_sq4));
+                    var_sq4), "sq2*sq2=sq4");
 
     // sq4 * t == sq5 == t^5
     this->pb.add_r1cs_constraint(
                 ConstraintT(
                     var_sq4,
                     t,
-                    var_sq5));
+                    var_sq5), "sq4*t=sq5");
 
     // 1 * (sq5 + x) = out
     this->pb.add_r1cs_constraint(
                 ConstraintT(
                     1,
                     var_sq5 + var_input_x,
-                    var_output));
+                    var_output), "sq5+x=out");
 }
 
 

--- a/src/gadgets/longsightl.hpp
+++ b/src/gadgets/longsightl.hpp
@@ -85,7 +85,7 @@ public:
         std::vector<VariableT> in_messages,
         const std::string &in_annotation_prefix=""
     ) :
-        MiyaguchiPreneel_OWF(in_pb, in_IV, in_messages, in_annotation_prefix)
+        MiyaguchiPreneel_OWF(in_pb, in_IV, in_messages, FMT(in_annotation_prefix, ".MP_OWF"))
     {
 
     }

--- a/src/gadgets/one_of_n.cpp
+++ b/src/gadgets/one_of_n.cpp
@@ -76,7 +76,7 @@ public:
         // ensure bitness of toggles
         for( size_t i = 0; i < items.size(); i++ )
         {
-            generate_boolean_r1cs_constraint<FieldT>(pb, toggles[i], FMT(annotation_prefix, " toggles_%zu", i));
+            generate_boolean_r1cs_constraint<FieldT>(pb, toggles[i], FMT(annotation_prefix, ".toggles_%zu_bitness", i));
         }
 
         // ensure the sum of toggles equals 1
@@ -86,13 +86,15 @@ public:
                 r1cs_constraint<FieldT>(
                     toggles_sum[i-1] + toggles[i],
                     FieldT::one(),
-                    toggles_sum[i]));
+                    toggles_sum[i]),
+                FMT(this->annotation_prefix, ".toggles_sum_%zu", i));
         }
         pb.add_r1cs_constraint(
                 r1cs_constraint<FieldT>(
                     toggles_sum[items.size()-1],
                     FieldT::one(),
-                    FieldT::one()));
+                    FieldT::one()),
+                FMT(this->annotation_prefix, ".toggles_sum_eq_1"));
 
         // XXX: why use `lc_val` here?
         auto our_item_lc_val = pb.lc_val(our_item);
@@ -105,7 +107,8 @@ public:
                 r1cs_constraint<FieldT>(
                     items[i],
                     toggles[i],
-                    toggles[i] * our_item_lc_val));
+                    toggles[i] * our_item_lc_val),
+                FMT(this->annotation_prefix, ".were_selected"));
         }
     }
 

--- a/src/gadgets/onewayfunction.hpp
+++ b/src/gadgets/onewayfunction.hpp
@@ -24,7 +24,7 @@ public:
 		m_messages(in_messages),
 		m_IV(in_IV)
 	{
-		m_outputs.allocate(in_pb, in_messages.size());
+		m_outputs.allocate(in_pb, in_messages.size(), FMT(this->annotation_prefix, ".outputs"));
 
 		int i = 0;		
 		for( auto& m_i : in_messages ) {
@@ -55,7 +55,7 @@ public:
 						1,
 						m_ciphers[i].result() + m_messages[i],
 						m_outputs[i]
-						));
+						), "E(m_i) + m_i = out");
 			}
 			else {
 				this->pb.add_r1cs_constraint(
@@ -63,7 +63,7 @@ public:
 						1,
 						m_outputs[i-1] + m_ciphers[i].result() + m_messages[i],
 						m_outputs[i]
-						));
+						), "E(m_i) + H_i-1 + m_i");
 			}
 		}
 	}

--- a/src/gadgets/sha256_full.cpp
+++ b/src/gadgets/sha256_full.cpp
@@ -123,9 +123,9 @@ public:
         const libff::bit_vector &in_block,
         const libff::bit_vector &in_expected_bv
     ) {
-        assert( in_block.size() == SHA256_block_size );
+        assert( in_block.size() == libsnark::SHA256_block_size );
 
-        assert( in_expected_bv.size() == SHA256_digest_size );
+        assert( in_expected_bv.size() == libsnark::SHA256_digest_size );
 
         input_block.generate_r1cs_witness(in_block);
 

--- a/src/gadgets/shamir_poly.cpp
+++ b/src/gadgets/shamir_poly.cpp
@@ -92,7 +92,8 @@ public:
                     r1cs_constraint<FieldT>(
                         FieldT::one(),
                         intermediate_squares[i],
-                        FieldT::one()));
+                        FieldT::one()),
+                    FMT(this->annotation_prefix, "1 * squares[%zu] = 1", i));
             }
             else if( i == 1 ) {
                 // (input * input) - S[2] = 0
@@ -100,7 +101,8 @@ public:
                     r1cs_constraint<FieldT>(
                         input,
                         input,
-                        intermediate_squares[i+1]));
+                        intermediate_squares[i+1]),
+                    FMT(this->annotation_prefix, "input * input = squares[%zu]", i));
             }
             else if( i < (alpha.size() - 1) ) {
                 // (I * S[i]) - S[i+1] = 0
@@ -108,7 +110,8 @@ public:
                     r1cs_constraint<FieldT>(
                         input,
                         intermediate_squares[i],
-                        intermediate_squares[i+1]));
+                        intermediate_squares[i+1]),
+                    FMT(this->annotation_prefix, "input * squares[%zu] = squares[%zu]", i, i+1));
             }
 
             // Totals
@@ -118,7 +121,8 @@ public:
                     r1cs_constraint<FieldT>(
                         alpha[i],
                         intermediate_squares[i],
-                        intermediate_total[i]));
+                        intermediate_total[i]),
+                    FMT(this->annotation_prefix, "alpha[%zu] * squares[%zu] = total[%zu]", i, i, i));
             }
             else {
                 // (A[i] * S[i]) - (T[i] - T[i-1]) = 0
@@ -126,7 +130,8 @@ public:
                     r1cs_constraint<FieldT>(
                         alpha[i],
                         intermediate_squares[i],
-                        (intermediate_total[i] - intermediate_total[i-1])));
+                        (intermediate_total[i] - intermediate_total[i-1])),
+                    FMT(this->annotation_prefix, "alpha[%zu] * squares[%zu] = (total[%zu] - total[%zu])", i, i, i, i-1));
             }
         }
     }

--- a/src/mod/hashpreimage.cpp
+++ b/src/mod/hashpreimage.cpp
@@ -93,9 +93,9 @@ public:
         const libff::bit_vector &in_block,
         const libff::bit_vector &in_expected_bv
     ) {
-        assert( in_block.size() == SHA256_block_size );
+        assert( in_block.size() == libsnark::SHA256_block_size );
 
-        assert( in_expected_bv.size() == SHA256_digest_size );
+        assert( in_expected_bv.size() == libsnark::SHA256_digest_size );
 
         input_block.generate_r1cs_witness(in_block);
 
@@ -132,7 +132,7 @@ public:
 
     static PrimaryInputT make_primary_input(const libff::bit_vector &in_block_bv)
     {
-        assert( in_block_bv.size() == SHA256_block_size );
+        assert( in_block_bv.size() == libsnark::SHA256_block_size );
 
         return libff::pack_bit_vector_into_field_element_vector<FieldT>(in_block_bv);
     }

--- a/src/mod/miximus.cpp
+++ b/src/mod/miximus.cpp
@@ -93,7 +93,7 @@ public:
         // logic gadgets
         spend_hash(in_pb, spend_hash_IV, {spend_preimage_var, nullifier_var}, FMT(annotation_prefix, ".spend_hash")),
         leaf_hash(in_pb, leaf_hash_IV, {nullifier_var, spend_hash.result()}, FMT(annotation_prefix, ".leaf_hash")),
-        m_authenticator(in_pb, tree_depth, address_bits, m_IVs, leaf_hash.result(), root_var, path_var)
+        m_authenticator(in_pb, tree_depth, address_bits, m_IVs, leaf_hash.result(), root_var, path_var, FMT(annotation_prefix, ".authenticator"))
     {
         in_pb.set_input_sizes( 3 );
     }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries(test_vk_raw2json ethsnarks_common)
 
 
 add_executable(test_shootout test_shootout.cpp)
-target_link_libraries(test_shootout snark)
+target_link_libraries(test_shootout ff)
 
 add_executable(test_load_proofkey test_load_proofkey.cpp)
 target_link_libraries(test_load_proofkey ethsnarks_common)
@@ -16,7 +16,7 @@ target_link_libraries(test_shamir_poly ethsnarks_common)
 
 
 add_executable(test_sha256_full_gadget test_sha256_full_gadget.cpp)
-target_link_libraries(test_sha256_full_gadget ethsnarks_common)
+target_link_libraries(test_sha256_full_gadget ethsnarks_common crypto)
 
 
 add_executable(test_proof_raw2json test_proof_raw2json.cpp)
@@ -24,7 +24,7 @@ target_link_libraries(test_proof_raw2json ethsnarks_common)
 
 
 add_executable(test_field_packing test_field_packing.cpp)
-target_link_libraries(test_field_packing ethsnarks_common)
+target_link_libraries(test_field_packing ethsnarks_common crypto)
 
 
 add_executable(test_merkle_tree test_merkle_tree.cpp)
@@ -32,7 +32,7 @@ target_link_libraries(test_merkle_tree ethsnarks_common)
 
 
 add_executable(test_hashpreimage test_hashpreimage.cpp)
-target_link_libraries(test_hashpreimage ethsnarks_common)
+target_link_libraries(test_hashpreimage ethsnarks_common crypto)
 
 
 add_executable(test_one_of_n test_one_of_n.cpp)

--- a/src/test/test_longsightl.cpp
+++ b/src/test/test_longsightl.cpp
@@ -21,10 +21,10 @@ bool test_LongsightL()
     VariableT in_x;
     VariableT in_k;
 
-    in_x.allocate(pb);
+    in_x.allocate(pb, "in_x");
     pb.val(in_x) = FieldT("3703141493535563179657531719960160174296085208671919316200479060314459804651");
 
-    in_k.allocate(pb);
+    in_k.allocate(pb, "in_k");
     pb.val(in_k) = FieldT("134551314051432487569247388144051420116740427803855572138106146683954151557");
 
     LongsightL_gadget the_gadget(pb, round_constants, in_x, in_k);

--- a/src/test/test_longsightl_hash_mp.cpp
+++ b/src/test/test_longsightl_hash_mp.cpp
@@ -18,15 +18,15 @@ bool test_LongsightL()
     VariableT m_1;
     VariableT iv;
 
-    m_0.allocate(pb);
+    m_0.allocate(pb, "m_0");
     pb.val(m_0) = FieldT("3703141493535563179657531719960160174296085208671919316200479060314459804651");
 
-    m_1.allocate(pb);
+    m_1.allocate(pb, "m_1");
     pb.val(m_1) = FieldT("134551314051432487569247388144051420116740427803855572138106146683954151557");
 
     pb.set_input_sizes(2);
 
-    iv.allocate(pb);
+    iv.allocate(pb, "iv");
     pb.val(iv) = FieldT("918403109389145570117360101535982733651217667914747213867238065296420114726");
 
     LongsightL12p5_MP_gadget the_gadget(pb, iv, {m_0, m_1});

--- a/src/test/test_merkle_tree.cpp
+++ b/src/test/test_merkle_tree.cpp
@@ -14,16 +14,16 @@ bool test_merkle_path_selector(int is_right)
 
 	is_right = is_right ? 1 : 0;
 
-	VariableT var_A = make_variable(pb);
+	VariableT var_A = make_variable(pb, "var_A");
 	pb.val(var_A) = value_A;
 
-	VariableT var_B = make_variable(pb);
+	VariableT var_B = make_variable(pb, "var_B");
 	pb.val(var_B) = value_B;
 
-	VariableT var_is_right = make_variable(pb);
+	VariableT var_is_right = make_variable(pb, "var_is_right");
 	pb.val(var_is_right) = is_right;
 
-	merkle_path_selector selector(pb, var_A, var_B, var_is_right);
+	merkle_path_selector selector(pb, var_A, var_B, var_is_right, "test_merkle_path_selector");
 
 	selector.generate_r1cs_witness();
 	selector.generate_r1cs_constraints();
@@ -58,19 +58,19 @@ bool test_merkle_path_authenticator() {
 	ProtoboardT pb;
 
 	VariableArrayT address_bits;
-	address_bits.allocate(pb, 1);
+	address_bits.allocate(pb, 1, "address_bits");
 	pb.val(address_bits[0]) = 1;
 
 	VariableArrayT path;
-	path.allocate(pb, 1);
+	path.allocate(pb, 1, "path");
 	pb.val(path[0]) = FieldT("3703141493535563179657531719960160174296085208671919316200479060314459804651");
 
 	VariableT leaf;
-	leaf.allocate(pb);
+	leaf.allocate(pb, "leaf");
 	pb.val(leaf) = FieldT("134551314051432487569247388144051420116740427803855572138106146683954151557");
 
 	VariableT expected_root;
-	expected_root.allocate(pb);
+	expected_root.allocate(pb, "expected_root");
 	pb.val(expected_root) = FieldT("12232803403448551110711645741717605608347940439638387632993385741901727947062");
 
 	size_t tree_depth = 1;

--- a/src/test/test_one_of_n.cpp
+++ b/src/test/test_one_of_n.cpp
@@ -22,12 +22,12 @@ bool test_one_of_n()
 
     // Allocate items first
     VariableArrayT in_items;    
-    in_items.allocate(pb, rand_items.size());
+    in_items.allocate(pb, rand_items.size(), "in_items");
     in_items.fill_with_field_elements(pb, rand_items);
 
     // Our item comes afterwards, is a private input
     VariableT in_our_item;
-    in_our_item.allocate(pb);
+    in_our_item.allocate(pb, "our_item");
     pb.val(in_our_item) = rand_items[3];
 
     // Setup gadget

--- a/src/test/test_sha256_full_gadget.cpp
+++ b/src/test/test_sha256_full_gadget.cpp
@@ -10,6 +10,7 @@
 using libsnark::digest_variable;
 using libsnark::block_variable;
 using libsnark::SHA256_digest_size;
+using libsnark::SHA256_block_size;
 
 using ethsnarks::ppT;
 

--- a/src/test/test_shamir_poly.cpp
+++ b/src/test/test_shamir_poly.cpp
@@ -29,10 +29,10 @@ bool test_shamirs_poly()
     pb_variable<FieldT> in_input;
     pb_variable_array<FieldT> in_alpha;
 
-    in_input.allocate(pb);
+    in_input.allocate(pb, "in_input");
     pb.val(in_input) = rand_input;
 
-    in_alpha.allocate(pb, rand_alpha.size());
+    in_alpha.allocate(pb, rand_alpha.size(), "in_alpha");
     in_alpha.fill_with_field_elements(pb, rand_alpha);
 
     shamir_poly<FieldT> the_gadget(pb, in_input, in_alpha);

--- a/src/test/test_shootout.cpp
+++ b/src/test/test_shootout.cpp
@@ -17,8 +17,8 @@ typedef ppT::Fp_type curve_Fr;
 int main() {
     curve_pp::init_public_params();
     #ifdef DEBUG
-    libsnark::inhibit_profiling_info = true;
-    libsnark::inhibit_profiling_counters = true;
+    libff::inhibit_profiling_info = true;
+    libff::inhibit_profiling_counters = true;
     #endif
 
     curve_G1 a = curve_G1::one();


### PR DESCRIPTION
This reduces the amount of libsnark code being compiled by making a special cut-down version of `libff` with only altbn128 support and the necessities, everything else is templated code and doesn't need a library.

This also reduces the number of duplicate compile flags, the compile flags are fully controlled in the `ethsnarks/CMakeLists.txt` file.

By default it's built with DEBUG enabled, for this reasons some bugs were caught were previously I was building with debug / assertions turned off.

However, the CMakeLists.txt file could be cleaned up, and things like optimisations and aggressive optimisations added back in for release / non-debug builds.

When Travis is building a tag, I think the optimisations etc. should be turned on.