### PR TITLE
Added FQ from py_ecc, changed shamir poly tests to use it

### DIFF
--- a/ethsnarks/field.py
+++ b/ethsnarks/field.py
@@ -1,0 +1,144 @@
+# Code copied from https://github.com/ethereum/py_ecc/blob/master/py_ecc/bn128/bn128_curve.py
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Vitalik Buterin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import sys
+from random import randint
+
+# python3 compatibility
+if sys.version_info.major == 2:
+    int_types = (int, long)  # noqa: F821
+else:
+    int_types = (int,)
+
+
+SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+# Extended euclidean algorithm to find modular inverses for
+# integers
+def inv(a, n):
+    if a == 0:
+        return 0
+    lm, hm = 1, 0
+    low, high = a % n, n
+    while low > 1:
+        r = high // low
+        nm, new = hm - lm * r, high - low * r
+        lm, low, hm, high = nm, new, lm, low
+    return lm % n
+
+
+# A class for field elements in FQ. Wrap a number in this class,
+# and it becomes a field element.
+class FQ(object):
+    __slots__ = ('n', 'm')
+
+    def __init__(self, n, field_modulus=SNARK_SCALAR_FIELD):
+        self.m = field_modulus
+        if isinstance(n, self.__class__):
+            self.n = n.n
+        else:
+            self.n = n % self.m
+        assert isinstance(self.n, int_types)
+
+    def _other_n(self, other):
+        if isinstance(other, FQ):
+            if other.m != self.m:
+                raise RuntimeError("Other field element has different modulus")
+            return other.n
+        if not isinstance(other, int_types):
+            raise RuntimeError("Not a valid value type: " + str(type(other).__name__))
+        return other
+
+    def __add__(self, other):
+        on = self._other_n(other)
+        return FQ((self.n + on) % self.m, self.m)
+
+    def __mul__(self, other):
+        on = self._other_n(other)
+        return FQ((self.n * on) % self.m, self.m)
+
+    def __rmul__(self, other):
+        return self * other
+
+    def __radd__(self, other):
+        return self + other
+
+    def __rsub__(self, other):
+        on = self._other_n(other)
+        return FQ((on - self.n) % self.m, self.m)
+
+    def __sub__(self, other):
+        on = self._other_n(other)
+        return FQ((self.n - on) % self.m, self.m)
+
+    def __div__(self, other):
+        on = self._other_n(other)
+        return FQ(self.n * inv(on, self.m) % self.m, self.m)
+
+    def __truediv__(self, other):
+        return self.__div__(other)
+
+    def __rdiv__(self, other):
+        on = self._other_n(other)
+        return FQ(inv(self.n, self.m) * on % self.m, self.m)
+
+    def __rtruediv__(self, other):
+        return self.__rdiv__(other)
+
+    def __pow__(self, other):
+        if other == 0:
+            return FQ(1, self.m)
+        elif other == 1:
+            return FQ(self.n, self.m)
+        elif other % 2 == 0:
+            return (self * self) ** (other // 2)
+        else:
+            return ((self * self) ** int(other // 2)) * self
+
+    def __eq__(self, other):
+        if other == 0.:
+            other = 0
+        return self.n == self._other_n(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __neg__(self):
+        return FQ(-self.n, self.m)
+
+    def __repr__(self):
+        return repr(self.n)
+
+    @classmethod
+    def random(cls, modulus=SNARK_SCALAR_FIELD):        
+        return FQ(randint(1, modulus - 1), modulus)
+
+    @classmethod
+    def one(cls, modulus=SNARK_SCALAR_FIELD):
+        return cls(1, modulus)
+
+    @classmethod
+    def zero(cls, modulus=SNARK_SCALAR_FIELD):
+        return cls(0, modulus)

--- a/ethsnarks/r1cs.py
+++ b/ethsnarks/r1cs.py
@@ -1,4 +1,11 @@
-from py_ecc.bn128 import curve_order
+from .field import FQ
 
 def r1cs_constraint(a, b, c):
-    assert ((((a * b) % curve_order) - c) % curve_order) == 0
+	if not isinstance(a, FQ):
+		a = FQ(a)
+	if not isinstance(b, FQ):
+		b = FQ(b)
+	if not isinstance(c, FQ):
+		c = FQ(c)
+	if not a * b == c:
+		raise RuntimeError("R1CS Constraint Failed!")

--- a/ethsnarks/shamirspoly.py
+++ b/ethsnarks/shamirspoly.py
@@ -1,36 +1,24 @@
 # Copyright (c) 2018 HarryR
 # License: LGPL-3.0+
 
-from random import randint
-from py_ecc.bn128 import curve_order
+from .field import FQ
 
 
-def randn(n):
-    assert n > 2
-    return randint(1, n-1)
-
-
-def randq():
-    return randn(curve_order)
-
-
-def shamirs_poly_n(x, a, n):
+def shamirs_poly(x, a):
     assert isinstance(a, (list,tuple))
     assert len(a) >= 2
+    assert isinstance(x, FQ)
 
     result = a[0]
     x_pow_i = x
 
     for i, a_i in list(enumerate(a))[1:]:
-        ai_mul_xi = (a_i * x_pow_i) % n
-        result = (result + ai_mul_xi) % n
+        assert isinstance(a_i, FQ)
+        ai_mul_xi = a_i * x_pow_i
+        result = result + ai_mul_xi
         x_pow_i *= x
 
     return result
-
-
-def shamirs_poly(x, a):
-    return shamirs_poly_n(x, a, curve_order)
 
 
 """
@@ -54,12 +42,14 @@ def lagrange(points, x):
     return total
 """
 
-def lagrange(points, x, mod=curve_order):
+def lagrange(points, x):
     # Borrowed from: https://gist.github.com/melpomene/2482930
     total = 0
     n = len(points)
     for i in range(n):
         xi, yi = points[i]
+        assert isinstance(xi, FQ)
+        assert isinstance(yi, FQ)
         def g(i, n):
             tot_mul = 1
             for j in range(n):
@@ -68,7 +58,7 @@ def lagrange(points, x, mod=curve_order):
                 xj, yj = points[j]
                 # Use integer division here, versus SciPy's which uses floating point division
                 # This loses precision with large values of P, which can't be easily recovered
-                tot_mul = (tot_mul * ( (x - xj) // (xi - xj) )) % mod
+                tot_mul = tot_mul * ( (x - xj) / (xi - xj) )
             return tot_mul
-        total = total + (yi * g(i, n)) % mod
+        total = total + (yi * g(i, n))
     return total

--- a/test/test_shamir_poly.py
+++ b/test/test_shamir_poly.py
@@ -1,6 +1,7 @@
 import unittest
 
-from ethsnarks.shamirspoly import lagrange, shamirs_poly, randq, randn, shamirs_poly_n
+from ethsnarks.shamirspoly import lagrange, shamirs_poly
+from ethsnarks.field import FQ
 from ethsnarks.r1cs import r1cs_constraint
 
 from scipy.interpolate import lagrange as scipy_lagrange
@@ -14,39 +15,41 @@ class ShamirPolyTests(unittest.TestCase):
     def test_fromdocs(self):
         p = 100003
         k = 4
-        a = [6257, 85026, 44499, 14701]
+        a = [FQ(6257, p), FQ(85026, p), FQ(44499, p), FQ(14701, p)]
         F = lambda i, x: a[i] * (x**i)
         X = lambda x: a[0] + F(1, x) + F(2, x) + F(3, x)
         # Create the shares
-        Sx = range(1, 5)
+        Sx = [_ for _ in range(1, 5)]
         Sy = [X(_) for _ in Sx]
         for x, y in zip(Sx, Sy):
-            print(x, y)
-            z = shamirs_poly_n(x, a, p)
-            assert z == y % p
+            z = shamirs_poly(FQ(x, p), a)
+            assert z == y
         # Then recover secret
-        assert a[0] == int(scipy_lagrange(Sx, Sy).c[-1])
+        result = int(scipy_lagrange(Sx, [_.n for _ in Sy]).c[-1]) % p
+        assert a[0] == result
+
 
     def test_fromdocs2(self):
         p = 100003
         k = 4
-        a = [randn(p) for _ in range(0, k)] # [6257, 85026, 44499, 14701]
+        a = [FQ.random(p) for _ in range(0, k)] # [6257, 85026, 44499, 14701]
         F = lambda i, x: a[i] * (x**i)
         X = lambda x: a[0] + F(1, x) + F(2, x) + F(3, x)
         # Create the shares
         Sx = range(1, 5)
         Sy = [X(_) for _ in Sx]
         for x, y in zip(Sx, Sy):
-            z = shamirs_poly_n(x, a, p)
-            assert z == y % p
+            z = shamirs_poly(FQ(x, p), a)
+            assert z == y
         # Then recover secret
-        assert a[0] == int(scipy_lagrange(Sx, Sy).c[-1])
+        result = int(scipy_lagrange(Sx, [_.n for _ in Sy]).c[-1]) % p
+        assert a[0] == result
 
     def test_random(self):
         # Randomized tests
         for _ in range(0, 10):
-            alpha = [randq() for _ in range(0, 4)]
-            points = [(i, shamirs_poly(i, alpha))
+            alpha = [FQ.random() for _ in range(0, 4)]
+            points = [(FQ(i), shamirs_poly(FQ(i), alpha))
                       for i in range(0, len(alpha))]
             assert alpha[0] == lagrange(points, 0)
             assert alpha[0] != lagrange(points[1:], 0)
@@ -55,57 +58,58 @@ class ShamirPolyTests(unittest.TestCase):
     def test_random_small(self):
         q = 100003
         for _ in range(0, 10):
-            alpha = [randn(q) for _ in range(0, 4)]
-            points = [(i, shamirs_poly_n(i, alpha, q))
+            alpha = [FQ.random(q) for _ in range(0, 4)]
+            points = [(FQ(i, q), shamirs_poly(FQ(i, q), alpha))
                       for i in range(0, len(alpha))]
-            assert alpha[0] == lagrange(points, 0, q)
-            assert alpha[0] != lagrange(points[1:], 0, q)
-            assert alpha[0] != lagrange(points[2:], 0, q)
+            assert alpha[0] == lagrange(points, 0)
+            assert alpha[0] != lagrange(points[1:], 0)
+            assert alpha[0] != lagrange(points[2:], 0)
 
             # XXX: scipy's lagrange has floating point precision for large numbers
             points_x, points_y = unzip(points)
-            interpolation = scipy_lagrange(points_x, points_y)
+            interpolation = scipy_lagrange([_.n for _ in points_x], [_.n for _ in points_y])
             assert int(interpolation.c[-1]) == alpha[0]
 
     def test_static(self):
         # Verify against static test vectors
-        alpha = [6808181831819141657160280673506432691407806061837762993142662373500430825792,
-                 4138536697521448323155976179625860582331141320072618244300034508091478437877,
-                 20259243729221075783953642258755031830946498253783650311586175820530608751936,
-                 11227115470523445882235139084890542822660569362938710556861479160600812964997]
-        points = [(i, shamirs_poly(i, alpha)) for i in range(0, len(alpha))]
-        test_points = [(0, 6808181831819141657160280673506432691407806061837762993142662373500430825792),
-                       (1, 20544834857245836424258632451520592838797650598216707762192147676147522484985),
-                       (2, 10833210933219706719196668784844423052753721417299010433393634464005858464330),
-                       (3, 1259517139202877390892412692306630092142705895884865660519589327528699562575)]
+        alpha = [FQ(6808181831819141657160280673506432691407806061837762993142662373500430825792),
+                 FQ(4138536697521448323155976179625860582331141320072618244300034508091478437877),
+                 FQ(20259243729221075783953642258755031830946498253783650311586175820530608751936),
+                 FQ(11227115470523445882235139084890542822660569362938710556861479160600812964997)]
+        points = [(FQ(i), shamirs_poly(FQ(i), alpha)) for i in range(0, len(alpha))]
+        test_points = [(FQ(0), FQ(6808181831819141657160280673506432691407806061837762993142662373500430825792)),
+                       (FQ(1), FQ(20544834857245836424258632451520592838797650598216707762192147676147522484985)),
+                       (FQ(2), FQ(10833210933219706719196668784844423052753721417299010433393634464005858464330)),
+                       (FQ(3), FQ(1259517139202877390892412692306630092142705895884865660519589327528699562575))]
         assert points == test_points
         assert alpha[0] == lagrange(points, 0)
 
     def test_poly_constraints(self):        
-        I = 14107816444829002666153088737167870815199986768206359534115449255516606414458
+        I = FQ(14107816444829002666153088737167870815199986768206359534115449255516606414458)
 
         A = [
-            17167899297711346731111134130539302906398306115120667361324654931060817769652,
-            20692971555607562002131076139518972969954851288604992618106076572794460197154,
-            11669314840495787582492056085422064523948780040073924653117253046363337959489,
-            15735493254427804666818698471807230275586165984790760178845725782084556556535
+            FQ(17167899297711346731111134130539302906398306115120667361324654931060817769652),
+            FQ(20692971555607562002131076139518972969954851288604992618106076572794460197154),
+            FQ(11669314840495787582492056085422064523948780040073924653117253046363337959489),
+            FQ(15735493254427804666818698471807230275586165984790760178845725782084556556535)
         ]
 
         S = [
-            1,
-            14107816444829002666153088737167870815199986768206359534115449255516606414458,
-            5067932324814081810415131337916762410698113547031307360925810907599032394672,
-            13201723662860499519704937914604513230538757359894370890481138582074383924053
+            FQ(1),
+            FQ(14107816444829002666153088737167870815199986768206359534115449255516606414458),
+            FQ(5067932324814081810415131337916762410698113547031307360925810907599032394672),
+            FQ(13201723662860499519704937914604513230538757359894370890481138582074383924053)
         ]
 
         T = [
-            17167899297711346731111134130539302906398306115120667361324654931060817769652,
-            13947767308050706262790594447202101821284419559667543268525874072511409211876,
-            12611939459072476081893406313696501745859572890147944797422704733972764295239,
-            1657398546220101661314129991806057074896482894269175421846876999103942041527
+            FQ(17167899297711346731111134130539302906398306115120667361324654931060817769652),
+            FQ(13947767308050706262790594447202101821284419559667543268525874072511409211876),
+            FQ(12611939459072476081893406313696501745859572890147944797422704733972764295239),
+            FQ(1657398546220101661314129991806057074896482894269175421846876999103942041527)
         ]
 
-        assert shamirs_poly(I, A) == T[-1]
+        result = shamirs_poly(I, A)
+        assert result == T[-1]
 
         for i in range(0, len(A)):
             if i == 0:


### PR DESCRIPTION
This imports the `FQ` class from `py_ecc` for dealing with modulo field elements.

It changes the Shamir's poly Python code to use this new class.