### PR TITLE
fix hashpreimage test error

### DIFF
--- a/ethsnarks/mod/hashpreimage.py
+++ b/ethsnarks/mod/hashpreimage.py
@@ -51,7 +51,7 @@ class HashPreimage(object):
         data = self._prove(pk_file_cstr, preimage_cstr)
         if data is None:
             raise RuntimeError("Could not prove!")
-        return Proof.from_json(data)
+        return Proof.from_json(data.decode("utf-8"))
 
     def verify(self, proof):
         if not isinstance(proof, Proof):


### PR DESCRIPTION
So there is an error in `e/m/hashpreimage.py` where it passes bytes instead of string. I added this conversion from string to bytes to convert this. But perhaps you know a better place for this fix to live.