### PR TITLE
 "pragma solidity" changed from 0.4.24 to ^0.4.24 for all contracts

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -11,6 +11,7 @@
 		"max-line-length": false,
 		"two-lines-top-level-separator": false,
 		"separate-by-one-line-in-contract": false,
-		"function-max-lines": false
+		"function-max-lines": false,
+		"compiler-fixed": false
 	}
 }

--- a/contracts/EdDSA.sol
+++ b/contracts/EdDSA.sol
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 @HarryR
 // License: LGPL-3.0+
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./JubJub.sol";
 

--- a/contracts/JubJub.sol
+++ b/contracts/JubJub.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 @yondonfu
 // License: LGPL-3.0+
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 library JubJub
 {

--- a/contracts/JubJubPublic.sol
+++ b/contracts/JubJubPublic.sol
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 @yondonfu
 // License: LGPL-3.0+
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./JubJub.sol";
 

--- a/contracts/LongsightL.sol
+++ b/contracts/LongsightL.sol
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 HarryR
 // License: LGPL-3.0+
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 library LongsightL
 {

--- a/contracts/MerkleTree.sol
+++ b/contracts/MerkleTree.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./LongsightL.sol";
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 contract Migrations {
     address public owner;

--- a/contracts/Miximus.sol
+++ b/contracts/Miximus.sol
@@ -17,7 +17,7 @@
     along with Miximus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./Verifier.sol";
 import "./SnarkUtils.sol";

--- a/contracts/Pairing.sol
+++ b/contracts/Pairing.sol
@@ -1,6 +1,6 @@
 // This code is taken from https://github.com/JacobEberhardt/ZoKrates
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 library Pairing {
     struct G1Point {

--- a/contracts/SnarkUtils.sol
+++ b/contracts/SnarkUtils.sol
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 HarryR
 // License: LGPL-3.0+
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 library SnarkUtils
 {

--- a/contracts/TestableMiximus.sol
+++ b/contracts/TestableMiximus.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./Miximus.sol";
 import "./Verifier.sol";

--- a/contracts/Verifier.sol
+++ b/contracts/Verifier.sol
@@ -1,6 +1,6 @@
 // this code is taken from https://github.com/JacobEberhardt/ZoKrates 
 
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 import "./Pairing.sol";
 


### PR DESCRIPTION
It feels fixing solidity compiler version is not strictly necessary, as it is anyway highly experimental software. At the same time it may complicate integration. Latest truffle e.g. provides 0.4.25 by default: https://github.com/trufflesuite/truffle/issues/1292