### PR TITLE
more tests for fixed_base_mul_zcash

### DIFF
--- a/src/jubjub/fixed_base_mul_zcash.cpp
+++ b/src/jubjub/fixed_base_mul_zcash.cpp
@@ -178,11 +178,11 @@ void fixed_base_mul_zcash::generate_r1cs_witness ()
 }
 
 const VariableT& fixed_base_mul_zcash::result_x() {
-	return edward_adders.back().result_x();
+	return edward_adders.size() ? edward_adders.back().result_x() : point_converters.back().result_x();
 }
 
 const VariableT& fixed_base_mul_zcash::result_y() {
-	return edward_adders.back().result_y();
+	return edward_adders.size() ? edward_adders.back().result_y() : point_converters.back().result_y();;
 }
 
 

--- a/src/jubjub/point.cpp
+++ b/src/jubjub/point.cpp
@@ -131,23 +131,14 @@ const EdwardsPoint EdwardsPoint::from_y_always (const FieldT in_y, const Params&
 
 const MontgomeryPoint EdwardsPoint::as_montgomery(const Params& in_params) const
 {
-    if(y == FieldT::one())
-    {
-        return {FieldT::zero(), FieldT::zero()}; //This should be infinity
-    }
-    else if (x.is_zero())
-    {
-        return {FieldT::zero(), FieldT::zero()};
-    }
-    else {
-        // The mapping is defined as above.
-        //
-        // (x, y) -> (u, v) where
-        //      u = (1 + y) / (1 - y)
-        //      v = u / x
-        FieldT u = (FieldT::one() + y) * (FieldT::one() - y).inverse();
-        return {u, in_params.scale * u * x.inverse()};
-    }
+    // The only points on the curve with x=0 or y=1 (for which birational equivalence is not valid), 
+    // are (0,1) and (0,-1), both of which are of low order, and should therefore not occur.
+    assert(!x.is_zero() && y != FieldT::one());
+    // (x, y) -> (u, v) where
+    //      u = (1 + y) / (1 - y)
+    //      v = u / x
+    FieldT u = (FieldT::one() + y) * (FieldT::one() - y).inverse();
+    return {u, in_params.scale * u * x.inverse()};
 }
 
 

--- a/src/test/jubjub/test_jubjub_mul_fixed_zcash.cpp
+++ b/src/test/jubjub/test_jubjub_mul_fixed_zcash.cpp
@@ -3,49 +3,85 @@
 
 namespace ethsnarks {
 
-bool test_jubjub_mul()
+using namespace jubjub;
+
+bool test_jubjub_mul(const FieldT& s, size_t size, const EdwardsPoint& expectedResult)
 {
     jubjub::Params params;
     ProtoboardT pb;
 
     VariableArrayT scalar;
-    scalar.allocate(pb, 252, "scalar");
-    scalar.fill_with_bits_of_field_element(pb, FieldT("6453482891510615431577168724743356132495662554103773572771861111634748265227"));
+    scalar.allocate(pb, size, "scalar");
+    scalar.fill_with_bits_of_field_element(pb, s);
 
-    // 252 bit require two base points
-    auto x_1 = FieldT("13819220147556003423829648734536813647484299520101079752658527049348033428680");
-    auto y_1 = FieldT("18418392512101013735016656943391868405135207372553011567997823284229347734793");
-    auto x_2 = FieldT("19958489783026433573316075700077866010553709103185244447986177585739896260337");
-    auto y_2 = FieldT("1343699924140874771493198820643387687812896216400603883310387613515125259878");
-
-    auto expected_x = FieldT("6996724116960126900867925506414577611960232042751977065057280053875878784636");
-    auto expected_y = FieldT("20701813187762697737769103062434791072108338775190080983238483435587088029101");
-
-    jubjub::fixed_base_mul_zcash the_gadget(pb, params, { {x_1, y_1}, {x_2, y_2} }, scalar, "the_gadget");
+    std::vector<EdwardsPoint> basepoints = {
+        {
+            FieldT("13418723823902222986275588345615650707197303761863176429873001977640541977977"),
+            FieldT("15255921313433251341520743036334816584226787412845488772781699434149539664639")
+        }, {
+            FieldT("11749872627669176692285695179399857264465143297451429569602068921530882657945"),
+            FieldT("2495745987765795949478491016197984302943511277003077751830848242972604164102")
+        }
+    };
+    jubjub::fixed_base_mul_zcash the_gadget(pb, params, basepoints, scalar, "the_gadget");
 
     the_gadget.generate_r1cs_witness();
     the_gadget.generate_r1cs_constraints();
 
-    if( pb.val(the_gadget.result_x()) != expected_x ) {
+    if( pb.val(the_gadget.result_x()) != expectedResult.x ) {
         std::cerr << "x mismatch: ";
 		pb.val(the_gadget.result_x()).print();
 		std::cerr << std::endl;
         return false;
     }
 
-    if( pb.val(the_gadget.result_y()) != expected_y ) {
+    if( pb.val(the_gadget.result_y()) != expectedResult.y ) {
         std::cerr << "y mismatch: ";
 		pb.val(the_gadget.result_y()).print();
 		std::cerr<< std::endl;
         return false;
     }
 
-    std::cout << pb.num_constraints() << " constraints" << std::endl;
-    std::cout << (pb.num_constraints() / float(scalar.size())) << " constraints per bit" << std::endl;
+    std::cout << "\t" << pb.num_constraints() << " constraints" << std::endl;
+    std::cout << "\t" << (pb.num_constraints() / float(scalar.size())) << " constraints per bit" << std::endl;
 
     return pb.is_satisfied();
 }
 
+bool test_jubjub_mul()
+{
+    std::cout << "Test 252bit point" << std::endl;
+    FieldT scalar("6453482891510615431577168724743356132495662554103773572771861111634748265227");
+    EdwardsPoint expected = {
+        FieldT("6545697115159207040330446958704617656199928059562637738348733874272425400594"),
+        FieldT("16414097465381367987194277536478439232201417933379523927469515207544654431390")
+    };
+    if (!test_jubjub_mul(scalar, 252, expected)) {
+        return false;
+    }
+
+    std::cout << "Test short (9bit) point" << std::endl;
+    scalar = FieldT("267");
+    expected = {
+        FieldT("6790798216812059804926342266703617627640027902964190490794793207272357201212"),
+        FieldT("2522797517250455013248440571887865304858084343310097011302610004060289809689")
+    };
+    if (!test_jubjub_mul(scalar, 9, expected)) {
+        return false;
+    }
+
+    std::cout << "Test point that needs padding (254bit)" << std::endl;
+    scalar = FieldT("21888242871839275222246405745257275088548364400416034343698204186575808495616");
+    expected = {
+        FieldT("16322787121012335146141962340685388833598805940095898416175167744309692564601"),
+        FieldT("7671892447502767424995649701270280747270481283542925053047237428072257876309")
+    };
+    if (!test_jubjub_mul(scalar, 255, expected)) {
+        return false;
+    }
+
+    return true;
+}
 
 // namespace ethsnarks
 }


### PR DESCRIPTION
This change enables this gadget to be used with scalars that only require one base-point (s < 186bits) and adds unit tests both for small as well as padded scalars.