### PR TITLE
Pass x lookup as a linear combination to avoid extra constraint

### DIFF
--- a/src/gadgets/lookup_signed_3bit.cpp
+++ b/src/gadgets/lookup_signed_3bit.cpp
@@ -12,7 +12,7 @@ void lookup_signed_3bit_constraints( ProtoboardT& pb, const std::vector<FieldT> 
 	// b0b1 = b[0] * b[1]
 	pb.add_r1cs_constraint(
         ConstraintT(b[0], b[1], b0b1),
-            FMT(annotation_prefix, ".result"));
+            FMT(annotation_prefix, ".b0&b1"));
 
 	// y_lc = c[0] + b[0] * (c[1]-c0) + b[1] * (c[2]-c[0]) + b[0]&b[1] * (c[3] - c[2] - c[1] + c[0])
 	LinearCombinationT y_lc;

--- a/src/jubjub/fixed_base_mul_zcash.cpp
+++ b/src/jubjub/fixed_base_mul_zcash.cpp
@@ -58,8 +58,18 @@ fixed_base_mul_zcash::fixed_base_mul_zcash(
 		const auto bits_begin = in_scalar.begin() + (i * chunk_size_bits);
 		const VariableArrayT window_bits_x( bits_begin, bits_begin + lookup_size_bits );
 		const VariableArrayT window_bits_y( bits_begin, bits_begin + chunk_size_bits );
-		m_windows_x.emplace_back(in_pb, lookup_x, window_bits_x, FMT(annotation_prefix, ".windows_x[%d]", i));
-		m_windows_y.emplace_back(in_pb, lookup_y, window_bits_y, FMT(annotation_prefix, ".windows_y[%d]", i));
+		m_windows_y.emplace_back(in_pb, lookup_y, window_bits_y, FMT(annotation_prefix, ".windows_y[%d]", i));		
+		
+		// Pass x lookup as a linear combination to avoid extra constraint.
+		// x_lc = c[0] + b[0] * (c[1]-c0) + b[1] * (c[2]-c[0]) + b[0]&b[1] * (c[3] - c[2] - c[1] + c[0])
+		LinearCombinationT x_lc;
+		x_lc.assign(in_pb,
+			LinearTermT(libsnark::ONE, lookup_x[0]) + 
+			LinearTermT(window_bits_x[0], (lookup_x[1] - lookup_x[0])) +
+			LinearTermT(window_bits_x[1], (lookup_x[2] - lookup_x[0])) +
+			LinearTermT(m_windows_y.back().b0b1, (lookup_x[3] - lookup_x[2] - lookup_x[1] + lookup_x[0]))
+		);
+		m_windows_x.emplace_back(x_lc);
 
 		// current is at 2^2 * start, for next iteration start needs to be 2^4
 		current = current.dbl(in_params);
@@ -72,9 +82,9 @@ fixed_base_mul_zcash::fixed_base_mul_zcash(
 		if( i % chunks_per_base_point == 1 ) {				
 			montgomery_adders.emplace_back(
 				in_pb, in_params,
-				m_windows_x[i-1].result(),
+				m_windows_x[i-1],
 				m_windows_y[i-1].result(),
-				m_windows_x[i].result(),
+				m_windows_x[i],
 				m_windows_y[i].result(),
 				FMT(this->annotation_prefix, ".mg_adders[%d]", i));
 		}
@@ -83,7 +93,7 @@ fixed_base_mul_zcash::fixed_base_mul_zcash(
 				in_pb, in_params,
 				montgomery_adders[i-2].result_x(),
 				montgomery_adders[i-2].result_y(),
-				m_windows_x[i].result(),
+				m_windows_x[i],
 				m_windows_y[i].result(),
 				FMT(this->annotation_prefix, ".mg_adders[%d]", i));
 		}
@@ -133,10 +143,6 @@ fixed_base_mul_zcash::fixed_base_mul_zcash(
 
 void fixed_base_mul_zcash::generate_r1cs_constraints ()
 {
-	for( auto& lut_x : m_windows_x ) {
-		lut_x.generate_r1cs_constraints();
-	}
-
 	for( auto& lut_y : m_windows_y ) {
 		lut_y.generate_r1cs_constraints();
 	}
@@ -156,12 +162,14 @@ void fixed_base_mul_zcash::generate_r1cs_constraints ()
 
 void fixed_base_mul_zcash::generate_r1cs_witness ()
 {
-	for( auto& lut_x : m_windows_x ) {
-		lut_x.generate_r1cs_witness();
-	}
-
+	// y lookups have to be solved first, because
+	// x depends on the `b0 && b1` constraint.
 	for( auto& lut_y : m_windows_y ) {
 		lut_y.generate_r1cs_witness();
+	}
+
+	for( auto& lut_x : m_windows_x ) {
+		lut_x.evaluate(this->pb);
 	}
 
 	for( auto& adder : montgomery_adders ) {

--- a/src/jubjub/fixed_base_mul_zcash.hpp
+++ b/src/jubjub/fixed_base_mul_zcash.hpp
@@ -4,7 +4,6 @@
 // Copyright (c) 2018 fleupold
 // License: LGPL-3.0+
 
-#include "gadgets/lookup_2bit.hpp"
 #include "gadgets/lookup_signed_3bit.hpp"
 #include "jubjub/adder.hpp"
 #include "jubjub/point.hpp"
@@ -22,7 +21,7 @@ public:
 	std::vector<MontgomeryAdder> montgomery_adders;
 	std::vector<MontgomeryToEdwards> point_converters;
 	std::vector<PointAdder> edward_adders;
-	std::vector<lookup_2bit_gadget> m_windows_x;
+	std::vector<LinearCombinationT> m_windows_x;
 	std::vector<lookup_signed_3bit_gadget> m_windows_y;
 
 	fixed_base_mul_zcash(

--- a/src/jubjub/montgomery.cpp
+++ b/src/jubjub/montgomery.cpp
@@ -10,9 +10,9 @@ namespace jubjub {
 MontgomeryAdder::MontgomeryAdder(
     ProtoboardT& in_pb,
     const Params& in_params,
-    const VariableT in_X1,
+    const LinearCombinationT in_X1,
     const VariableT in_Y1,
-    const VariableT in_X2,
+    const LinearCombinationT in_X2,
     const VariableT in_Y2,
     const std::string &annotation_prefix
 ) :
@@ -50,9 +50,9 @@ const VariableT& MontgomeryAdder::result_y() const
 
 void MontgomeryAdder::generate_r1cs_witness()
 {
-    this->pb.val(lambda) = (this->pb.val(m_Y2) - this->pb.val(m_Y1)) * (this->pb.val(m_X2) - this->pb.val(m_X1)).inverse();
-    this->pb.val(m_X3) = this->pb.val(lambda).squared() - m_params.A - this->pb.val(m_X1) - this->pb.val(m_X2);
-    this->pb.val(m_Y3) = -(this->pb.val(m_Y1) + (this->pb.val(lambda)*(this->pb.val(m_X3) - this->pb.val(m_X1))));
+    this->pb.val(lambda) = (this->pb.val(m_Y2) - this->pb.val(m_Y1)) * (this->pb.lc_val(m_X2) - this->pb.lc_val(m_X1)).inverse();
+    this->pb.val(m_X3) = this->pb.val(lambda).squared() - m_params.A - this->pb.lc_val(m_X1) - this->pb.lc_val(m_X2);
+    this->pb.val(m_Y3) = -(this->pb.val(m_Y1) + (this->pb.val(lambda)*(this->pb.val(m_X3) - this->pb.lc_val(m_X1))));
 }
 
 

--- a/src/jubjub/montgomery.hpp
+++ b/src/jubjub/montgomery.hpp
@@ -18,11 +18,11 @@ public:
     const Params& m_params;
 
     // First input point
-    const VariableT m_X1;
+    const LinearCombinationT m_X1;
     const VariableT m_Y1;
 
     // Second input point
-    const VariableT m_X2;
+    const LinearCombinationT m_X2;
     const VariableT m_Y2;
 
     // Intermediate variables
@@ -33,9 +33,9 @@ public:
     MontgomeryAdder(
         ProtoboardT& in_pb,
         const Params& in_params,
-        const VariableT in_X1,
+        const LinearCombinationT in_X1,
         const VariableT in_Y1,
-        const VariableT in_X2,
+        const LinearCombinationT in_X2,
         const VariableT in_Y2,
         const std::string& annotation_prefix
     );


### PR DESCRIPTION
It turns out we can save the x lookup constraint for fixed base multiplication if instead we pass the value around as a linear combination (which can be evaluated for free as part of the Montgomery addition constraints).

This is also how zCash does it (see https://github.com/zcash/librustzcash/issues/47 for more context).

This reduces 252bit multiplication from 512 to 428 constraints.