### PR TITLE
Use native CMake mechanism for finding OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if(${CURVE} STREQUAL "BN128")
 endif()
 
 if("${MULTICORE}")
+  find_package(OpenMP REQUIRED)
   add_definitions(-DMULTICORE=1)
 endif()
 
@@ -152,9 +153,6 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Common compilation flags and warning configuration
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wfatal-errors -Wno-unused-variable")
-   if("${MULTICORE}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
-  endif()
     # Default optimizations flags (to override, use -DOPT_FLAGS=...)
 endif()
 
@@ -226,10 +224,15 @@ target_include_directories(ff PUBLIC
   ${DEPENDS_DIR_LIBSNARK} ${DEPENDS_DIR_LIBFF} ${DEPENDS_DIR_LIBFQFFT})
 target_compile_features(ff PUBLIC cxx_std_11)
 
+
 target_include_directories(ff INTERFACE
   ${DEPENDS_DIR_LIBSNARK} ${DEPENDS_DIR_LIBFF} ${DEPENDS_DIR_LIBFQFFT})
 target_compile_features(ff INTERFACE cxx_std_11)
 
 target_link_libraries(ff GMP::gmp ${PROCPS_LIBRARIES})
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(ff OpenMP::OpenMP_CXX)
+endif()
 
 add_subdirectory(src)

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ cmake-debug: build
 cmake-release: build
 	cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
 
+cmake-openmp-debug: build
+	cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DMULTICORE=1 ..
+
+cmake-openmp-release: build
+	cd build && cmake -DCMAKE_BUILD_TYPE=Release -DMULTICORE=1 ..
+
 release: cmake-release all
 
 debug: cmake-debug all


### PR DESCRIPTION
This fixes OpenMP support when using ethsnarks as a submodule.

Adds the `cmake-openmp-debug` and `cmake-openmp-release` targets to the top-level Makefile.