### PR TITLE
Propogate the 'DEBUG' definition, otherwise FMT() won't work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,10 +122,6 @@ if("${MULTICORE}")
   add_definitions(-DMULTICORE=1)
 endif()
 
-if("${DEBUG}" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  add_definitions(-DDEBUG=1)
-endif()
-
 if("${USE_ASM}")
   add_definitions(-DUSE_ASM)
 endif()
@@ -244,6 +240,11 @@ target_include_directories(ff PUBLIC
   ${DEPENDS_DIR_LIBSNARK} ${DEPENDS_DIR_LIBFF} ${DEPENDS_DIR_LIBFQFFT})
 target_compile_features(ff PUBLIC cxx_std_11)
 
+
+if("${DEBUG}" OR "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  add_definitions(-DDEBUG=1)
+  target_compile_definitions(ff PUBLIC DEBUG=1)
+endif()
 
 target_include_directories(ff INTERFACE
   ${DEPENDS_DIR_LIBSNARK} ${DEPENDS_DIR_LIBFF} ${DEPENDS_DIR_LIBFQFFT})


### PR DESCRIPTION
This applies to programs which use ethsnarks as a submodule or as a cmake module.

The problem occurs when the `libff` library has `assert` enabled and requires the annotation prefix to be non-empty, but in the program that uses the library the `DEBUG` flag isn't propagated so `FMT` returns an empty string.