### PR TITLE
Add ability to insert last leaf to the tree

### DIFF
--- a/contracts/MerkleTree.sol
+++ b/contracts/MerkleTree.sol
@@ -76,7 +76,7 @@ library MerkleTree
 
         uint256 offset = self.cur;
 
-        require (offset != MAX_LEAF_COUNT - 1);
+        require (offset < MAX_LEAF_COUNT);
 
         self.leaves[0][offset] = leaf;
 


### PR DESCRIPTION
It looks like it is necessary to replace `MAX_LEAF_COUNT - 1` with `MAX_LEAF_COUNT`. Because it is impossible to insert the last leaf in the current implementation.