### PR TITLE
Add Fr field class to the field.py

### DIFF
--- a/ethsnarks/field.py
+++ b/ethsnarks/field.py
@@ -37,9 +37,10 @@ if sys.version_info.major > 2:
 else:
     int_types = (int, long)  # noqa: F821
 
-
+# Fq is the base field of Jubjub
 SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617
-
+# Fr is the scalar field of Jubjub
+FR_ORDER = 21888242871839275222246405745257275088614511777268538073601725287587578984328
 
 # A class for field elements in FQ. Wrap a number in this class,
 # and it becomes a field element.
@@ -203,3 +204,8 @@ class FQ(object):
         if isinstance(modulus, FQ):
             modulus = modulus.m
         return FQ(0, modulus)
+
+class FR(FQ):
+    def __init__(self, n, field_modulus=FR_ORDER):
+        FQ.__init__(self, n, field_modulus)
+


### PR DESCRIPTION
Added Fr field for jubjub curve. 
`FR` class inherits `FQ` and the example code is below

```python
from ethsnarks.field import FQ, FR 
from ethsnarks.jubjub import Point

G = Point.from_y(FQ(20819045374670962167435360035096875258406992893633759881276124905556507972311))

def test_homomorphic_encryption():
    a = FR(3)
    b = FR(-1)
    P = G*(a+b)
    Q = G*a + G*b

    print("a:                       ", a)      # a: 3
    print("b:                       ", b)      # b: 21888242871839275222246405745257275088614511777268538073601725287587578984327
    print("G*(a+b):                 ", P)      # x: 173245..., y: 200221...
    print("G*(a) + G(b):            ", Q)      # x: 173245..., y: 200221...
    print("G*(a+b) == G*(a) + G(b): ", P == Q) # True

if __name__ == "__main__":
    test_homomorphic_encryption()

```